### PR TITLE
Five BigQuery-exclusive GSC tools, rebased onto v4.1.1 (no dist/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server for BigQuery that lets you ask Claude questions about your search and analytics data warehouse and get real answers. Not raw query results. Actual analysis with verdicts and recommendations.
 
-33 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
+34 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
 
 > **Full setup guide with screenshots:** [suganthan.com/blog/bigquery-mcp-server/](https://suganthan.com/blog/bigquery-mcp-server/)
 >
@@ -113,9 +113,9 @@ Your service account needs three IAM roles: **BigQuery Data Editor**, **BigQuery
 >
 > **Want the GA4 + GSC blending tools too?** Add the GA4 BigQuery export and one extra environment variable (`BIGQUERY_GA4_DATASET`). Full walkthrough: [GA4 + GSC in BigQuery setup guide](https://suganthan.com/blog/google-analytics-bigquery-mcp-server/).
 
-## All 33 tools
+## All 34 tools
 
-### BigQuery exclusive (9)
+### BigQuery exclusive (10)
 
 These use BigQuery capabilities the Search Console API simply doesn't have.
 
@@ -130,6 +130,7 @@ These use BigQuery capabilities the Search Console API simply doesn't have.
 | `gsc_intent_breakdown` | Classify all queries by search intent: informational, transactional, commercial, navigational. |
 | `gsc_ngrams` | Extract recurring terms from queries. Find themes your content should cover. |
 | `gsc_new_keywords` | Queries appearing in recent data that weren't present before. |
+| `gsc_query_count` | How many distinct queries a site, section or single URL is visible for, by position group, over time, against the previous period. Counts the whole export instead of a 1,000-row page, and reads the anonymised share from `is_anonymized_query` instead of inferring it. |
 
 ### GSC analysis (12)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server for BigQuery that lets you ask Claude questions about your search and analytics data warehouse and get real answers. Not raw query results. Actual analysis with verdicts and recommendations.
 
-36 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
+37 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
 
 > **Full setup guide with screenshots:** [suganthan.com/blog/bigquery-mcp-server/](https://suganthan.com/blog/bigquery-mcp-server/)
 >
@@ -113,9 +113,9 @@ Your service account needs three IAM roles: **BigQuery Data Editor**, **BigQuery
 >
 > **Want the GA4 + GSC blending tools too?** Add the GA4 BigQuery export and one extra environment variable (`BIGQUERY_GA4_DATASET`). Full walkthrough: [GA4 + GSC in BigQuery setup guide](https://suganthan.com/blog/google-analytics-bigquery-mcp-server/).
 
-## All 36 tools
+## All 37 tools
 
-### BigQuery exclusive (12)
+### BigQuery exclusive (13)
 
 These use BigQuery capabilities the Search Console API simply doesn't have.
 
@@ -133,6 +133,7 @@ These use BigQuery capabilities the Search Console API simply doesn't have.
 | `gsc_query_count` | How many distinct queries a site, section or single URL is visible for, by position group, over time, against the previous period. Counts the whole export instead of a 1,000-row page, and reads the anonymised share from `is_anonymized_query` instead of inferring it. |
 | `gsc_discover` | Google Discover performance: clicks, impressions, CTR, share of all surfaces, time series, top URLs, country split. Page-based, with its own `is_anonymized_discover` flag. |
 | `gsc_click_curve` | Your own click curve: CTR per rank measured on your data, not borrowed from a study. Segment by device, country, surface, or branded vs non-branded. Also reports the clicks it cannot cover. |
+| `gsc_shopping` | Organic shopping surfaces: free product listings, merchant listings, product snippets. Search appearances inside WEB rows, so they cross freely with url, query, device and date - unlike the API's `searchAppearance` dimension. |
 
 ### GSC analysis (12)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server for BigQuery that lets you ask Claude questions about your search and analytics data warehouse and get real answers. Not raw query results. Actual analysis with verdicts and recommendations.
 
-37 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
+38 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
 
 > **Full setup guide with screenshots:** [suganthan.com/blog/bigquery-mcp-server/](https://suganthan.com/blog/bigquery-mcp-server/)
 >
@@ -113,9 +113,9 @@ Your service account needs three IAM roles: **BigQuery Data Editor**, **BigQuery
 >
 > **Want the GA4 + GSC blending tools too?** Add the GA4 BigQuery export and one extra environment variable (`BIGQUERY_GA4_DATASET`). Full walkthrough: [GA4 + GSC in BigQuery setup guide](https://suganthan.com/blog/google-analytics-bigquery-mcp-server/).
 
-## All 37 tools
+## All 38 tools
 
-### BigQuery exclusive (13)
+### BigQuery exclusive (14)
 
 These use BigQuery capabilities the Search Console API simply doesn't have.
 
@@ -134,6 +134,7 @@ These use BigQuery capabilities the Search Console API simply doesn't have.
 | `gsc_discover` | Google Discover performance: clicks, impressions, CTR, share of all surfaces, time series, top URLs, country split. Page-based, with its own `is_anonymized_discover` flag. |
 | `gsc_click_curve` | Your own click curve: CTR per rank measured on your data, not borrowed from a study. Segment by device, country, surface, or branded vs non-branded. Also reports the clicks it cannot cover. |
 | `gsc_shopping` | Organic shopping surfaces: free product listings, merchant listings, product snippets. Search appearances inside WEB rows, so they cross freely with url, query, device and date - unlike the API's `searchAppearance` dimension. |
+| `gsc_image_search` | Google Images: clicks, impressions, CTR, position, share of all surfaces, top pages and queries, AMP image results. `url` is the hosting page, not the image file. |
 
 ### GSC analysis (12)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server for BigQuery that lets you ask Claude questions about your search and analytics data warehouse and get real answers. Not raw query results. Actual analysis with verdicts and recommendations.
 
-34 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
+35 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
 
 > **Full setup guide with screenshots:** [suganthan.com/blog/bigquery-mcp-server/](https://suganthan.com/blog/bigquery-mcp-server/)
 >
@@ -113,9 +113,9 @@ Your service account needs three IAM roles: **BigQuery Data Editor**, **BigQuery
 >
 > **Want the GA4 + GSC blending tools too?** Add the GA4 BigQuery export and one extra environment variable (`BIGQUERY_GA4_DATASET`). Full walkthrough: [GA4 + GSC in BigQuery setup guide](https://suganthan.com/blog/google-analytics-bigquery-mcp-server/).
 
-## All 34 tools
+## All 35 tools
 
-### BigQuery exclusive (10)
+### BigQuery exclusive (11)
 
 These use BigQuery capabilities the Search Console API simply doesn't have.
 
@@ -131,6 +131,7 @@ These use BigQuery capabilities the Search Console API simply doesn't have.
 | `gsc_ngrams` | Extract recurring terms from queries. Find themes your content should cover. |
 | `gsc_new_keywords` | Queries appearing in recent data that weren't present before. |
 | `gsc_query_count` | How many distinct queries a site, section or single URL is visible for, by position group, over time, against the previous period. Counts the whole export instead of a 1,000-row page, and reads the anonymised share from `is_anonymized_query` instead of inferring it. |
+| `gsc_discover` | Google Discover performance: clicks, impressions, CTR, share of all surfaces, time series, top URLs, country split. Page-based, with its own `is_anonymized_discover` flag. |
 
 ### GSC analysis (12)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server for BigQuery that lets you ask Claude questions about your search and analytics data warehouse and get real answers. Not raw query results. Actual analysis with verdicts and recommendations.
 
-35 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
+36 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
 
 > **Full setup guide with screenshots:** [suganthan.com/blog/bigquery-mcp-server/](https://suganthan.com/blog/bigquery-mcp-server/)
 >
@@ -113,9 +113,9 @@ Your service account needs three IAM roles: **BigQuery Data Editor**, **BigQuery
 >
 > **Want the GA4 + GSC blending tools too?** Add the GA4 BigQuery export and one extra environment variable (`BIGQUERY_GA4_DATASET`). Full walkthrough: [GA4 + GSC in BigQuery setup guide](https://suganthan.com/blog/google-analytics-bigquery-mcp-server/).
 
-## All 35 tools
+## All 36 tools
 
-### BigQuery exclusive (11)
+### BigQuery exclusive (12)
 
 These use BigQuery capabilities the Search Console API simply doesn't have.
 
@@ -132,6 +132,7 @@ These use BigQuery capabilities the Search Console API simply doesn't have.
 | `gsc_new_keywords` | Queries appearing in recent data that weren't present before. |
 | `gsc_query_count` | How many distinct queries a site, section or single URL is visible for, by position group, over time, against the previous period. Counts the whole export instead of a 1,000-row page, and reads the anonymised share from `is_anonymized_query` instead of inferring it. |
 | `gsc_discover` | Google Discover performance: clicks, impressions, CTR, share of all surfaces, time series, top URLs, country split. Page-based, with its own `is_anonymized_discover` flag. |
+| `gsc_click_curve` | Your own click curve: CTR per rank measured on your data, not borrowed from a study. Segment by device, country, surface, or branded vs non-branded. Also reports the clicks it cannot cover. |
 
 ### GSC analysis (12)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import { gscGenaiConversationQueries } from "./tools/gsc-genai-conversation-quer
 // Export-only surfaces and counts the Search Console API cannot return.
 import { gscQueryCount } from "./tools/gsc-query-count.js";
 import { gscDiscover } from "./tools/gsc-discover.js";
+import { gscClickCurve } from "./tools/gsc-click-curve.js";
 
 const server = new McpServer({
   name: "bigquery-mcp",
@@ -859,10 +860,35 @@ server.tool(
   }
 );
 
+// The click curve, measured on this property instead of borrowed from a study
+server.tool(
+  "gsc_click_curve",
+  "Build the click curve from your own data: CTR per ranking position, measured instead of borrowed from a study. Aggregates to (url, query) pairs, takes each pair's average position, rounds it to a rank, then divides summed clicks by summed impressions per rank. Segment by device, country, search_type, or branded vs non-branded with a brand_pattern - the branded split matters most, because branded queries inflate a blended curve at the top. Also reports how many clicks the curve cannot cover, because anonymized rows carry no position." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX + POSITION_CAVEAT,
+  {
+    days: z.number().default(90).describe("Number of days to analyse. Longer is better here: the curve needs volume per rank."),
+    max_position: z.number().default(20).describe("Highest rank to include"),
+    min_impressions_per_rank: z.number().default(100).describe("Drop ranks below this many impressions instead of reporting noise"),
+    segment_by: z.enum(["none", "device", "country", "search_type", "branded"]).default("none").describe("Split the curve by this dimension"),
+    brand_pattern: z.string().optional().describe("Regex for branded queries, required when segment_by is branded, e.g. yourbrand"),
+    search_type: z.enum(["WEB", "IMAGE", "VIDEO", "NEWS", "GOOGLE_NEWS"]).default("WEB").describe("Surface to measure. Ignored when segment_by is search_type."),
+    url_contains: z.string().optional().describe("Restrict to URLs containing this string, e.g. to get a curve for one section"),
+    dataset: z.string().optional().describe("BigQuery dataset containing GSC data"),
+  },
+  async ({ days, max_position, min_impressions_per_rank, segment_by, brand_pattern, search_type, url_contains, dataset }) => {
+    try {
+      const results = await gscClickCurve(days, max_position, min_impressions_per_rank, segment_by, brand_pattern, search_type, url_contains, dataset);
+      const wrapped = withMeta(results, "gsc_click_curve", { days, max_position, min_impressions_per_rank, segment_by, brand_pattern, search_type, url_contains, dataset });
+      return { content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }] };
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("BigQuery MCP server v4.1.1 running on stdio (35 tools)");
+  console.error("BigQuery MCP server v4.1.1 running on stdio (36 tools)");
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { gscGenaiConversationQueries } from "./tools/gsc-genai-conversation-quer
 import { gscQueryCount } from "./tools/gsc-query-count.js";
 import { gscDiscover } from "./tools/gsc-discover.js";
 import { gscClickCurve } from "./tools/gsc-click-curve.js";
+import { gscShopping } from "./tools/gsc-shopping.js";
 
 const server = new McpServer({
   name: "bigquery-mcp",
@@ -885,10 +886,33 @@ server.tool(
   }
 );
 
+// Organic shopping surfaces, as columns rather than the API's searchAppearance
+server.tool(
+  "gsc_shopping",
+  "Organic shopping surfaces: free product listings (is_organic_shopping), merchant listings (is_merchant_listings) and product snippets (is_product_snippets). These are search appearances inside WEB rows, so unlike the API searchAppearance dimension they can be crossed with url, query, device and date freely. Without an appearance argument it returns all three side by side; pass one to drill into its top URLs, top queries and time series. A property that sells nothing returns zeros - that is a finding, and the note field says so." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX + POSITION_CAVEAT,
+  {
+    days: z.number().default(28).describe("Number of days to analyse"),
+    appearance: z.enum(["organic_shopping", "merchant_listings", "product_snippets"]).optional().describe("Drill into one appearance. Omit for the overview of all three."),
+    granularity: z.enum(["none", "day", "week", "month"]).default("week").describe("Bucket size for the drilldown time series"),
+    url_contains: z.string().optional().describe("Restrict to URLs containing this string"),
+    top_rows: z.number().default(50).describe("How many URLs and queries to return in the drilldown"),
+    dataset: z.string().optional().describe("BigQuery dataset containing GSC data"),
+  },
+  async ({ days, appearance, granularity, url_contains, top_rows, dataset }) => {
+    try {
+      const results = await gscShopping(days, appearance, granularity, url_contains, top_rows, dataset);
+      const wrapped = withMeta(results, "gsc_shopping", { days, appearance, granularity, url_contains, top_rows, dataset });
+      return { content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }] };
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("BigQuery MCP server v4.1.1 running on stdio (36 tools)");
+  console.error("BigQuery MCP server v4.1.1 running on stdio (37 tools)");
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,8 @@ import { ga4GscPositionValue } from "./tools/ga4-gsc-position-value.js";
 import { ga4GscBrandedPerformance } from "./tools/ga4-gsc-branded-performance.js";
 // v4.1 generative AI tools — AI Mode conversation exhaust in the query table.
 import { gscGenaiConversationQueries } from "./tools/gsc-genai-conversation-queries.js";
+// Export-only surfaces and counts the Search Console API cannot return.
+import { gscQueryCount } from "./tools/gsc-query-count.js";
 
 const server = new McpServer({
   name: "bigquery-mcp",
@@ -806,10 +808,38 @@ server.tool(
   }
 );
 
+// Query counting across the whole export, not a 1,000-row API page
+server.tool(
+  "gsc_query_count",
+  "Count how many distinct queries a property, a section or a single URL is visible for, split by position group (1-3, 4-10, 11-20, 21-50, 51+), against the previous period of equal length. Scope with url or url_contains, add a time series with granularity, narrow with min_position/max_position, rank pages with top_pages. Unlike the API version this counts the whole export instead of a 1,000-row page, and reads the anonymized share from is_anonymized_query rather than inferring it from a click gap." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX + POSITION_CAVEAT,
+  {
+    days: z.number().default(28).describe("Number of days to analyse"),
+    url: z.string().optional().describe("Count only queries for this exact URL"),
+    url_contains: z.string().optional().describe("Count only queries for URLs containing this string, e.g. /guides/"),
+    granularity: z.enum(["none", "day", "week", "month"]).default("none").describe("Add a time series of distinct query counts"),
+    min_position: z.number().optional().describe("Only count queries at this average position or worse (e.g. 4)"),
+    max_position: z.number().optional().describe("Only count queries at this average position or better (e.g. 10)"),
+    search_type: z.enum(["WEB", "IMAGE", "VIDEO", "NEWS", "GOOGLE_NEWS"]).default("WEB").describe("Surface to count. Discover has no queries; use gsc_discover."),
+    top_pages: z.number().optional().describe("Also rank this many pages by query count"),
+    device: z.enum(["MOBILE", "DESKTOP", "TABLET"]).optional().describe("Restrict to one device. Omit for all devices, which is the default."),
+    country: z.string().optional().describe("Restrict to one country as an ISO-3166-1 alpha-3 code, e.g. usa, gbr, deu. Omit for all countries, which is the default."),
+    dataset: z.string().optional().describe("BigQuery dataset containing GSC data"),
+  },
+  async ({ days, url, url_contains, granularity, min_position, max_position, search_type, top_pages, device, country, dataset }) => {
+    try {
+      const results = await gscQueryCount(days, url, url_contains, granularity, min_position, max_position, search_type, top_pages, device, country, dataset);
+      const wrapped = withMeta(results, "gsc_query_count", { days, url, url_contains, granularity, min_position, max_position, search_type, top_pages, device, country, dataset });
+      return { content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }] };
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("BigQuery MCP server v4.1.1 running on stdio (33 tools)");
+  console.error("BigQuery MCP server v4.1.1 running on stdio (34 tools)");
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import { gscQueryCount } from "./tools/gsc-query-count.js";
 import { gscDiscover } from "./tools/gsc-discover.js";
 import { gscClickCurve } from "./tools/gsc-click-curve.js";
 import { gscShopping } from "./tools/gsc-shopping.js";
+import { gscImageSearch } from "./tools/gsc-image-search.js";
 
 const server = new McpServer({
   name: "bigquery-mcp",
@@ -909,10 +910,32 @@ server.tool(
   }
 );
 
+// Google Images, including the AMP image slice
+server.tool(
+  "gsc_image_search",
+  "Google Images performance from the export: clicks, impressions, CTR, average position, share of all surfaces, time series, top pages, top queries, device and country split, plus the AMP-image-result slice. Unlike Discover, image search does carry queries. Note that url is the page hosting the image, not the image file - the export has no image-level dimension." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX + POSITION_CAVEAT,
+  {
+    days: z.number().default(28).describe("Number of days to analyse"),
+    granularity: z.enum(["none", "day", "week", "month"]).default("week").describe("Bucket size for the time series"),
+    url_contains: z.string().optional().describe("Restrict to URLs containing this string"),
+    top_rows: z.number().default(50).describe("How many pages and queries to return"),
+    dataset: z.string().optional().describe("BigQuery dataset containing GSC data"),
+  },
+  async ({ days, granularity, url_contains, top_rows, dataset }) => {
+    try {
+      const results = await gscImageSearch(days, granularity, url_contains, top_rows, dataset);
+      const wrapped = withMeta(results, "gsc_image_search", { days, granularity, url_contains, top_rows, dataset });
+      return { content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }] };
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("BigQuery MCP server v4.1.1 running on stdio (37 tools)");
+  console.error("BigQuery MCP server v4.1.1 running on stdio (38 tools)");
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import { ga4GscBrandedPerformance } from "./tools/ga4-gsc-branded-performance.js
 import { gscGenaiConversationQueries } from "./tools/gsc-genai-conversation-queries.js";
 // Export-only surfaces and counts the Search Console API cannot return.
 import { gscQueryCount } from "./tools/gsc-query-count.js";
+import { gscDiscover } from "./tools/gsc-discover.js";
 
 const server = new McpServer({
   name: "bigquery-mcp",
@@ -836,10 +837,32 @@ server.tool(
   }
 );
 
+// Google Discover: page-based, no query dimension, its own anonymisation flag
+server.tool(
+  "gsc_discover",
+  "Google Discover performance from the export: clicks, impressions, CTR, its share of all surfaces, a time series, top URLs, device and country split. Discover is page-based, so nothing groups by query, and its anonymisation is tracked separately via is_anonymized_discover." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX,
+  {
+    days: z.number().default(28).describe("Number of days to analyse"),
+    granularity: z.enum(["none", "day", "week", "month"]).default("week").describe("Bucket size for the time series"),
+    url_contains: z.string().optional().describe("Restrict to URLs containing this string"),
+    top_urls: z.number().default(50).describe("How many top URLs to return"),
+    dataset: z.string().optional().describe("BigQuery dataset containing GSC data"),
+  },
+  async ({ days, granularity, url_contains, top_urls, dataset }) => {
+    try {
+      const results = await gscDiscover(days, granularity, url_contains, top_urls, dataset);
+      const wrapped = withMeta(results, "gsc_discover", { days, granularity, url_contains, top_urls, dataset });
+      return { content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }] };
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("BigQuery MCP server v4.1.1 running on stdio (34 tools)");
+  console.error("BigQuery MCP server v4.1.1 running on stdio (35 tools)");
 }
 
 main().catch((error) => {

--- a/src/tools/gsc-click-curve.ts
+++ b/src/tools/gsc-click-curve.ts
@@ -1,0 +1,150 @@
+import { runQuery } from "./query.js";
+import { getConfig, validateIdentifier } from "../client.js";
+import {
+  AVG_POSITION_SQL,
+  normaliseSearchType,
+  escapeSQLString,
+  getLastExportDate,
+} from "./gsc-shared.js";
+
+type QueryResult = { rows: Record<string, unknown>[]; totalRows: number; bytesProcessed: string };
+
+export type CurveSegment = "none" | "device" | "country" | "search_type" | "branded";
+
+/**
+ * Your own click curve: CTR by ranking position, measured on your data.
+ *
+ * Every "expected CTR by position" table in an SEO tool is somebody else's
+ * average - usually a study across unrelated sites. This builds the curve from
+ * the export: aggregate to (url, query), take that pair's average position,
+ * round it to a rank, then sum clicks and impressions per rank. CTR is the
+ * ratio of those sums, never an average of ratios, so high-volume pairs carry
+ * the weight they should.
+ *
+ * With segment_by="branded" and a brand_pattern, the branded and non-branded
+ * curves come back separately - the split that matters most, because branded
+ * queries inflate a blended curve at the top and make everything else look
+ * like it underperforms.
+ */
+export async function gscClickCurve(
+  days: number = 90,
+  maxPosition: number = 20,
+  minImpressionsPerRank: number = 100,
+  segmentBy: CurveSegment = "none",
+  brandPattern?: string,
+  searchType: string = "WEB",
+  urlContains?: string,
+  dataset?: string
+): Promise<{
+  period: { startDate: string; endDate: string; days: number; anchoredTo: string };
+  method: string;
+  curve: QueryResult;
+  coverage: QueryResult;
+}> {
+  const config = getConfig();
+  const ds = dataset || config.defaultDataset || "searchconsole";
+  validateIdentifier(ds, "dataset");
+  const type = normaliseSearchType(searchType);
+
+  if (type === "DISCOVER") {
+    throw new Error(
+      "Discover has no ranking positions, so there is no click curve to build. Use gsc_discover instead."
+    );
+  }
+  if (segmentBy === "branded" && !brandPattern) {
+    throw new Error(
+      'segment_by="branded" needs brand_pattern, e.g. "homeandsmart" or "brand|brandname".'
+    );
+  }
+
+  const lastDay = await getLastExportDate(ds, runQuery);
+  const table = `\`${ds}.searchdata_url_impression\``;
+
+  const window = `data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days} DAY)
+      AND data_date <= DATE '${lastDay}'`;
+  const urlScope = urlContains ? `AND url LIKE '%${escapeSQLString(urlContains)}%'` : "";
+
+  let segmentExpr = "'all'";
+  if (segmentBy === "device") segmentExpr = "device";
+  if (segmentBy === "country") segmentExpr = "country";
+  if (segmentBy === "search_type") segmentExpr = "search_type";
+  if (segmentBy === "branded") {
+    segmentExpr = `IF(REGEXP_CONTAINS(query, r'(?i)${escapeSQLString(brandPattern!)}'), 'branded', 'non-branded')`;
+  }
+
+  // search_type stays unfiltered when it is the segment, otherwise it is pinned.
+  const typeScope = segmentBy === "search_type" ? "" : `AND search_type = '${type}'`;
+
+  const curveSQL = `
+    WITH per_pair AS (
+      SELECT
+        ${segmentExpr} AS segment,
+        url,
+        query,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ${AVG_POSITION_SQL} AS position
+      FROM ${table}
+      WHERE ${window}
+        AND query IS NOT NULL
+        ${typeScope}
+        ${urlScope}
+      GROUP BY segment, url, query
+    ),
+    ranked AS (
+      SELECT
+        segment,
+        CAST(ROUND(position) AS INT64) AS rank,
+        clicks,
+        impressions
+      FROM per_pair
+    )
+    SELECT
+      segment,
+      rank AS position,
+      SUM(impressions) AS impressions,
+      SUM(clicks) AS clicks,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 3) AS ctr_pct,
+      COUNT(*) AS url_query_pairs
+    FROM ranked
+    WHERE rank BETWEEN 1 AND ${maxPosition}
+    GROUP BY segment, rank
+    HAVING impressions >= ${minImpressionsPerRank}
+    ORDER BY segment, position
+    LIMIT 2000
+  `;
+
+  // What the curve does NOT cover, stated rather than left implicit: anonymized
+  // rows carry no query and no position, so they can never enter it.
+  const coverageSQL = `
+    SELECT
+      SUM(clicks) AS total_clicks,
+      SUM(IF(is_anonymized_query, clicks, 0)) AS anonymized_clicks,
+      ROUND(SAFE_DIVIDE(SUM(IF(is_anonymized_query, clicks, 0)), SUM(clicks)) * 100, 2)
+        AS anonymized_clicks_share_pct,
+      COUNT(DISTINCT query) AS distinct_queries
+    FROM ${table}
+    WHERE ${window}
+      ${typeScope}
+      ${urlScope}
+    LIMIT 1
+  `;
+
+  const [curve, coverage] = await Promise.all([runQuery(curveSQL, 2000), runQuery(coverageSQL, 1)]);
+
+  const start = new Date(lastDay);
+  start.setUTCDate(start.getUTCDate() - days + 1);
+
+  return {
+    period: {
+      startDate: start.toISOString().split("T")[0],
+      endDate: lastDay,
+      days,
+      anchoredTo: `latest day in the export (${lastDay}), not today`,
+    },
+    method:
+      "CTR per rank = SUM(clicks) / SUM(impressions) over (url, query) pairs whose average position rounds to that rank. Average position uses sum_position/impressions + 1, because sum_position is zero-based. Ranks below min_impressions_per_rank are dropped rather than reported as noise.",
+    curve,
+    coverage,
+  };
+}

--- a/src/tools/gsc-discover.ts
+++ b/src/tools/gsc-discover.ts
@@ -1,0 +1,156 @@
+import { runQuery } from "./query.js";
+import { getConfig, validateIdentifier } from "../client.js";
+import {
+  GRANULARITY_TRUNC,
+  Granularity,
+  escapeSQLString,
+  getLastExportDate,
+} from "./gsc-shared.js";
+
+type QueryResult = { rows: Record<string, unknown>[]; totalRows: number; bytesProcessed: string };
+
+/**
+ * Google Discover performance from the bulk export.
+ *
+ * Discover is page-based: there is no query dimension, so nothing here groups
+ * by query. Its own anonymisation flag is `is_anonymized_discover`, separate
+ * from `is_anonymized_query`.
+ *
+ * There is deliberately no device breakdown: `device` is NULL on every Discover
+ * row, so the block only ever returned a single empty bucket holding every
+ * click. Mobile versus desktop is not answerable for this surface.
+ */
+export async function gscDiscover(
+  days: number = 28,
+  granularity: Granularity = "week",
+  urlContains?: string,
+  topUrls: number = 50,
+  dataset?: string
+): Promise<{
+  period: { startDate: string; endDate: string; days: number; anchoredTo: string };
+  summary: QueryResult;
+  shareOfSite: QueryResult;
+  timeSeries: QueryResult | null;
+  topUrls: QueryResult;
+  byCountry: QueryResult;
+}> {
+  const config = getConfig();
+  const ds = dataset || config.defaultDataset || "searchconsole";
+  validateIdentifier(ds, "dataset");
+
+  const lastDay = await getLastExportDate(ds, runQuery);
+  const table = `\`${ds}.searchdata_url_impression\``;
+
+  const window = `data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days} DAY)
+      AND data_date <= DATE '${lastDay}'`;
+  const urlScope = urlContains ? `AND url LIKE '%${escapeSQLString(urlContains)}%'` : "";
+
+  const summarySQL = `
+    SELECT
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      COUNT(DISTINCT url) AS urls,
+      SUM(IF(is_anonymized_discover, clicks, 0)) AS anonymized_clicks,
+      ROUND(SAFE_DIVIDE(SUM(IF(is_anonymized_discover, clicks, 0)), SUM(clicks)) * 100, 2)
+        AS anonymized_clicks_share_pct
+    FROM ${table}
+    WHERE ${window}
+      AND search_type = 'DISCOVER'
+      ${urlScope}
+    LIMIT 1
+  `;
+
+  // Discover next to the other surfaces, so its weight is visible rather than
+  // stated in isolation.
+  const shareOfSiteSQL = `
+    SELECT
+      search_type,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(SUM(clicks)) OVER ()) * 100, 2) AS click_share_pct
+    FROM ${table}
+    WHERE ${window}
+      ${urlScope}
+    GROUP BY search_type
+    ORDER BY clicks DESC
+    LIMIT 10
+  `;
+
+  let timeSeriesSQL: string | null = null;
+  if (granularity !== "none") {
+    timeSeriesSQL = `
+      SELECT
+        DATE_TRUNC(data_date, ${GRANULARITY_TRUNC[granularity]}) AS bucket,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+        COUNT(DISTINCT url) AS urls
+      FROM ${table}
+      WHERE ${window}
+        AND search_type = 'DISCOVER'
+        ${urlScope}
+      GROUP BY bucket
+      ORDER BY bucket
+      LIMIT 400
+    `;
+  }
+
+  const topUrlsSQL = `
+    SELECT
+      url,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      MIN(data_date) AS first_day,
+      MAX(data_date) AS last_day
+    FROM ${table}
+    WHERE ${window}
+      AND search_type = 'DISCOVER'
+      ${urlScope}
+    GROUP BY url
+    ORDER BY clicks DESC
+    LIMIT ${Math.min(topUrls, 500)}
+  `;
+
+  const byCountrySQL = `
+    SELECT
+      country,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct
+    FROM ${table}
+    WHERE ${window}
+      AND search_type = 'DISCOVER'
+      ${urlScope}
+    GROUP BY country
+    ORDER BY clicks DESC
+    LIMIT 20
+  `;
+
+  const [summary, shareOfSite, timeSeries, topUrlsResult, byCountry] = await Promise.all([
+    runQuery(summarySQL, 1),
+    runQuery(shareOfSiteSQL, 10),
+    timeSeriesSQL ? runQuery(timeSeriesSQL, 400) : Promise.resolve(null),
+    runQuery(topUrlsSQL, Math.min(topUrls, 500)),
+    runQuery(byCountrySQL, 20),
+  ]);
+
+  const start = new Date(lastDay);
+  start.setUTCDate(start.getUTCDate() - days + 1);
+
+  return {
+    period: {
+      startDate: start.toISOString().split("T")[0],
+      endDate: lastDay,
+      days,
+      anchoredTo: `latest day in the export (${lastDay}), not today`,
+    },
+    summary,
+    shareOfSite,
+    timeSeries,
+    topUrls: topUrlsResult,
+    byCountry,
+  };
+}

--- a/src/tools/gsc-image-search.ts
+++ b/src/tools/gsc-image-search.ts
@@ -1,0 +1,210 @@
+import { runQuery } from "./query.js";
+import { getConfig, validateIdentifier } from "../client.js";
+import {
+  AVG_POSITION_SQL,
+  GRANULARITY_TRUNC,
+  Granularity,
+  escapeSQLString,
+  getLastExportDate,
+} from "./gsc-shared.js";
+
+type QueryResult = { rows: Record<string, unknown>[]; totalRows: number; bytesProcessed: string };
+
+/**
+ * Google Images performance from the bulk export.
+ *
+ * Unlike Discover, image search does carry queries, so this groups by both url
+ * and query. The url is the page the image sits on, never the image file - the
+ * export has no image-level dimension, which is the honest limit of this
+ * surface and the reason a low image CTR says little about the image itself.
+ *
+ * `is_amp_image_result` is reported alongside, because an AMP image result is a
+ * different SERP element from an ordinary image result.
+ */
+export async function gscImageSearch(
+  days: number = 28,
+  granularity: Granularity = "week",
+  urlContains?: string,
+  topRows: number = 50,
+  dataset?: string
+): Promise<{
+  period: { startDate: string; endDate: string; days: number; anchoredTo: string };
+  summary: QueryResult;
+  shareOfSite: QueryResult;
+  timeSeries: QueryResult | null;
+  topUrls: QueryResult;
+  topQueries: QueryResult;
+  byDevice: QueryResult;
+  byCountry: QueryResult;
+  note: string;
+}> {
+  const config = getConfig();
+  const ds = dataset || config.defaultDataset || "searchconsole";
+  validateIdentifier(ds, "dataset");
+
+  const lastDay = await getLastExportDate(ds, runQuery);
+  const table = `\`${ds}.searchdata_url_impression\``;
+
+  const window = `data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days} DAY)
+      AND data_date <= DATE '${lastDay}'`;
+  const urlScope = urlContains ? `AND url LIKE '%${escapeSQLString(urlContains)}%'` : "";
+  const imageScope = `AND search_type = 'IMAGE'`;
+  const limit = Math.min(topRows, 500);
+
+  const summarySQL = `
+    SELECT
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+      COUNT(DISTINCT url) AS urls,
+      COUNT(DISTINCT query) AS visible_queries,
+      SUM(IF(is_anonymized_query, clicks, 0)) AS anonymized_clicks,
+      ROUND(SAFE_DIVIDE(SUM(IF(is_anonymized_query, clicks, 0)), SUM(clicks)) * 100, 2)
+        AS anonymized_clicks_share_pct,
+      SUM(IF(is_amp_image_result, clicks, 0)) AS amp_image_result_clicks,
+      SUM(IF(is_amp_image_result, impressions, 0)) AS amp_image_result_impressions
+    FROM ${table}
+    WHERE ${window}
+      ${imageScope}
+      ${urlScope}
+    LIMIT 1
+  `;
+
+  const shareOfSiteSQL = `
+    SELECT
+      search_type,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(SUM(clicks)) OVER ()) * 100, 2) AS click_share_pct
+    FROM ${table}
+    WHERE ${window}
+      ${urlScope}
+    GROUP BY search_type
+    ORDER BY clicks DESC
+    LIMIT 10
+  `;
+
+  let timeSeriesSQL: string | null = null;
+  if (granularity !== "none") {
+    timeSeriesSQL = `
+      SELECT
+        DATE_TRUNC(data_date, ${GRANULARITY_TRUNC[granularity]}) AS bucket,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+        ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+        COUNT(DISTINCT url) AS urls
+      FROM ${table}
+      WHERE ${window}
+        ${imageScope}
+        ${urlScope}
+      GROUP BY bucket
+      ORDER BY bucket
+      LIMIT 400
+    `;
+  }
+
+  const topUrlsSQL = `
+    SELECT
+      url,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+      COUNT(DISTINCT query) AS queries
+    FROM ${table}
+    WHERE ${window}
+      ${imageScope}
+      ${urlScope}
+    GROUP BY url
+    ORDER BY impressions DESC
+    LIMIT ${limit}
+  `;
+
+  const topQueriesSQL = `
+    SELECT
+      query,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+      COUNT(DISTINCT url) AS urls
+    FROM ${table}
+    WHERE ${window}
+      ${imageScope}
+      AND query IS NOT NULL
+      ${urlScope}
+    GROUP BY query
+    ORDER BY impressions DESC
+    LIMIT ${limit}
+  `;
+
+  const byDeviceSQL = `
+    SELECT
+      device,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      ROUND(${AVG_POSITION_SQL}, 1) AS avg_position
+    FROM ${table}
+    WHERE ${window}
+      ${imageScope}
+      ${urlScope}
+    GROUP BY device
+    ORDER BY clicks DESC
+    LIMIT 10
+  `;
+
+  const byCountrySQL = `
+    SELECT
+      country,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct
+    FROM ${table}
+    WHERE ${window}
+      ${imageScope}
+      ${urlScope}
+    GROUP BY country
+    ORDER BY clicks DESC
+    LIMIT 20
+  `;
+
+  const [summary, shareOfSite, timeSeries, topUrls, topQueries, byDevice, byCountry] =
+    await Promise.all([
+      runQuery(summarySQL, 1),
+      runQuery(shareOfSiteSQL, 10),
+      timeSeriesSQL ? runQuery(timeSeriesSQL, 400) : Promise.resolve(null),
+      runQuery(topUrlsSQL, limit),
+      runQuery(topQueriesSQL, limit),
+      runQuery(byDeviceSQL, 10),
+      runQuery(byCountrySQL, 20),
+    ]);
+
+  const start = new Date(lastDay);
+  start.setUTCDate(start.getUTCDate() - days + 1);
+
+  const impressions = Number(summary.rows[0]?.impressions ?? 0);
+
+  return {
+    period: {
+      startDate: start.toISOString().split("T")[0],
+      endDate: lastDay,
+      days,
+      anchoredTo: `latest day in the export (${lastDay}), not today`,
+    },
+    summary,
+    shareOfSite,
+    timeSeries,
+    topUrls,
+    topQueries,
+    byDevice,
+    byCountry,
+    note:
+      impressions > 0
+        ? "url is the page hosting the image, not the image file: the export carries no image-level dimension. A weak CTR here therefore points at the page and its thumbnail in the grid, not necessarily at the image itself."
+        : "No image search impressions in this window. Either the property is not indexed in Google Images, or images are served from a different property than this one.",
+  };
+}

--- a/src/tools/gsc-query-count.ts
+++ b/src/tools/gsc-query-count.ts
@@ -1,0 +1,239 @@
+import { runQuery } from "./query.js";
+import { getConfig, validateIdentifier } from "../client.js";
+import {
+  AVG_POSITION_SQL,
+  positionGroupSQL,
+  GRANULARITY_TRUNC,
+  Granularity,
+  normaliseSearchType,
+  escapeSQLString,
+  getLastExportDate,
+  deviceCountryConditions,
+} from "./gsc-shared.js";
+
+type QueryResult = { rows: Record<string, unknown>[]; totalRows: number; bytesProcessed: string };
+
+/**
+ * Query counting on the warehouse instead of the API.
+ *
+ * Two things this can do that the API version cannot: it counts across the full
+ * export instead of a 1,000-row page, and it reads the anonymized share from
+ * the `is_anonymized_query` flag rather than inferring it from a click gap.
+ */
+export async function gscQueryCount(
+  days: number = 28,
+  url?: string,
+  urlContains?: string,
+  granularity: Granularity = "none",
+  minPosition?: number,
+  maxPosition?: number,
+  searchType: string = "WEB",
+  topPages?: number,
+  device?: string,
+  country?: string,
+  dataset?: string
+): Promise<{
+  period: { startDate: string; endDate: string; days: number; anchoredTo: string };
+  totals: QueryResult;
+  byPositionGroup: QueryResult;
+  periodComparison: QueryResult;
+  timeSeries: QueryResult | null;
+  topPagesByQueryCount: QueryResult | null;
+}> {
+  const config = getConfig();
+  const ds = dataset || config.defaultDataset || "searchconsole";
+  validateIdentifier(ds, "dataset");
+  const type = normaliseSearchType(searchType);
+
+  if (type === "DISCOVER") {
+    throw new Error(
+      "Discover carries no query dimension, so there is nothing to count. Use gsc_discover instead."
+    );
+  }
+
+  const lastDay = await getLastExportDate(ds, runQuery);
+  const table = `\`${ds}.searchdata_url_impression\``;
+
+  const scope: string[] = [`search_type = '${type}'`];
+  if (url) scope.push(`url = '${escapeSQLString(url)}'`);
+  if (urlContains) scope.push(`url LIKE '%${escapeSQLString(urlContains)}%'`);
+  scope.push(...deviceCountryConditions(device, country, type));
+  const scopeSQL = scope.length ? `AND ${scope.join("\n      AND ")}` : "";
+
+  const currentWindow = `data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days} DAY)
+      AND data_date <= DATE '${lastDay}'`;
+
+  const positionFilter: string[] = [];
+  if (minPosition !== undefined) positionFilter.push(`position >= ${minPosition}`);
+  if (maxPosition !== undefined) positionFilter.push(`position <= ${maxPosition}`);
+  const positionFilterSQL = positionFilter.length ? `WHERE ${positionFilter.join(" AND ")}` : "";
+
+  // The anonymized gap is deliberately NOT position-filtered: anonymized rows
+  // carry no query and therefore no position, so filtering would just hide them.
+  const totalsSQL = `
+    SELECT
+      COUNT(DISTINCT query) AS visible_queries,
+      SUM(IF(is_anonymized_query, 0, clicks)) AS clicks_from_visible_queries,
+      SUM(clicks) AS total_clicks,
+      SUM(IF(is_anonymized_query, clicks, 0)) AS anonymized_clicks,
+      ROUND(SAFE_DIVIDE(SUM(IF(is_anonymized_query, clicks, 0)), SUM(clicks)) * 100, 2)
+        AS anonymized_clicks_share_pct,
+      SUM(impressions) AS total_impressions
+    FROM ${table}
+    WHERE ${currentWindow}
+      ${scopeSQL}
+    LIMIT 1
+  `;
+
+  const byPositionGroupSQL = `
+    WITH per_query AS (
+      SELECT
+        query,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ${AVG_POSITION_SQL} AS position
+      FROM ${table}
+      WHERE ${currentWindow}
+        AND query IS NOT NULL
+        ${scopeSQL}
+      GROUP BY query
+    )
+    SELECT
+      ${positionGroupSQL("position")} AS position_group,
+      COUNT(*) AS queries,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct
+    FROM per_query
+    ${positionFilterSQL}
+    GROUP BY position_group
+    ORDER BY MIN(position)
+    LIMIT 10
+  `;
+
+  const periodComparisonSQL = `
+    WITH tagged AS (
+      SELECT
+        query,
+        clicks,
+        impressions,
+        sum_position,
+        IF(
+          data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days} DAY),
+          'current',
+          'previous'
+        ) AS period
+      FROM ${table}
+      WHERE data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days * 2} DAY)
+        AND data_date <= DATE '${lastDay}'
+        AND query IS NOT NULL
+        ${scopeSQL}
+    ),
+    per_period_query AS (
+      SELECT
+        period,
+        query,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ${AVG_POSITION_SQL} AS position
+      FROM tagged
+      GROUP BY period, query
+    )
+    SELECT
+      period,
+      COUNT(*) AS visible_queries,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions
+    FROM per_period_query
+    ${positionFilterSQL}
+    GROUP BY period
+    ORDER BY period DESC
+    LIMIT 2
+  `;
+
+  let timeSeriesSQL: string | null = null;
+  if (granularity !== "none") {
+    const trunc = GRANULARITY_TRUNC[granularity];
+    timeSeriesSQL = `
+      WITH per_bucket_query AS (
+        SELECT
+          DATE_TRUNC(data_date, ${trunc}) AS bucket,
+          query,
+          SUM(clicks) AS clicks,
+          SUM(impressions) AS impressions,
+          ${AVG_POSITION_SQL} AS position
+        FROM ${table}
+        WHERE ${currentWindow}
+          AND query IS NOT NULL
+          ${scopeSQL}
+        GROUP BY bucket, query
+      )
+      SELECT
+        bucket,
+        COUNT(*) AS visible_queries,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct
+      FROM per_bucket_query
+      ${positionFilterSQL}
+      GROUP BY bucket
+      ORDER BY bucket
+      LIMIT 400
+    `;
+  }
+
+  let topPagesSQL: string | null = null;
+  if (topPages && topPages > 0) {
+    topPagesSQL = `
+      WITH per_page_query AS (
+        SELECT
+          url,
+          query,
+          SUM(clicks) AS clicks,
+          SUM(impressions) AS impressions,
+          ${AVG_POSITION_SQL} AS position
+        FROM ${table}
+        WHERE ${currentWindow}
+          AND query IS NOT NULL
+          ${scopeSQL}
+        GROUP BY url, query
+      )
+      SELECT
+        url,
+        COUNT(*) AS queries,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ROUND(AVG(position), 1) AS avg_position
+      FROM per_page_query
+      ${positionFilterSQL}
+      GROUP BY url
+      ORDER BY queries DESC
+      LIMIT ${Math.min(topPages, 500)}
+    `;
+  }
+
+  const [totals, byPositionGroup, periodComparison, timeSeries, topPagesResult] = await Promise.all([
+    runQuery(totalsSQL, 1),
+    runQuery(byPositionGroupSQL, 10),
+    runQuery(periodComparisonSQL, 2),
+    timeSeriesSQL ? runQuery(timeSeriesSQL, 400) : Promise.resolve(null),
+    topPagesSQL ? runQuery(topPagesSQL, Math.min(topPages || 0, 500)) : Promise.resolve(null),
+  ]);
+
+  const startDateSQL = new Date(lastDay);
+  startDateSQL.setUTCDate(startDateSQL.getUTCDate() - days + 1);
+
+  return {
+    period: {
+      startDate: startDateSQL.toISOString().split("T")[0],
+      endDate: lastDay,
+      days,
+      anchoredTo: `latest day in the export (${lastDay}), not today`,
+    },
+    totals,
+    byPositionGroup,
+    periodComparison,
+    timeSeries,
+    topPagesByQueryCount: topPagesResult,
+  };
+}

--- a/src/tools/gsc-shared.ts
+++ b/src/tools/gsc-shared.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared SQL building blocks for the GSC bulk export tables.
+ */
+
+/**
+ * Average position from the GSC bulk export.
+ *
+ * `sum_position` is ZERO-BASED, so the average rank is sum/impressions + 1.
+ * Verified against a live export: over one week, 12,544 of 411,617 (url, query)
+ * pairs have sum_position/impressions below 1 and the minimum is exactly 0 -
+ * and position 0 does not exist in Google Search.
+ *
+ * This matches the `+ 1` the rest of the server applies since v4.1.1.
+ */
+export const AVG_POSITION_SQL = "SAFE_DIVIDE(SUM(sum_position), SUM(impressions)) + 1";
+
+/** Position group buckets, matching query_count in the GSC API MCP server. */
+export function positionGroupSQL(column: string): string {
+  return `CASE
+        WHEN ${column} <= 3 THEN '1-3'
+        WHEN ${column} <= 10 THEN '4-10'
+        WHEN ${column} <= 20 THEN '11-20'
+        WHEN ${column} <= 50 THEN '21-50'
+        ELSE '51+'
+      END`;
+}
+
+export type Granularity = "none" | "day" | "week" | "month";
+
+export const GRANULARITY_TRUNC: Record<Exclude<Granularity, "none">, string> = {
+  day: "DAY",
+  week: "WEEK(MONDAY)",
+  month: "MONTH",
+};
+
+/** Search types as spelled in the export (uppercase, unlike the API). */
+export const SEARCH_TYPES = ["WEB", "IMAGE", "VIDEO", "NEWS", "GOOGLE_NEWS", "DISCOVER"] as const;
+export type ExportSearchType = (typeof SEARCH_TYPES)[number];
+
+export function normaliseSearchType(value: string): ExportSearchType {
+  const upper = value.toUpperCase().replace(/-/g, "_") as ExportSearchType;
+  if (!SEARCH_TYPES.includes(upper)) {
+    throw new Error(
+      `Unknown search_type "${value}". Allowed: ${SEARCH_TYPES.join(", ")}.`
+    );
+  }
+  return upper;
+}
+
+/** Devices as spelled in the export. */
+export const DEVICES = ["MOBILE", "DESKTOP", "TABLET"] as const;
+export type Device = (typeof DEVICES)[number];
+
+export function normaliseDevice(value: string): Device {
+  const upper = value.toUpperCase() as Device;
+  if (!DEVICES.includes(upper)) {
+    throw new Error(`Unknown device "${value}". Allowed: ${DEVICES.join(", ")}.`);
+  }
+  return upper;
+}
+
+/** Countries are ISO-3166-1 alpha-3, lowercase in the export (deu, aut, che, usa). */
+export function normaliseCountry(value: string): string {
+  const lower = value.toLowerCase();
+  if (!/^[a-z]{3}$/.test(lower)) {
+    throw new Error(
+      `Country must be an ISO-3166-1 alpha-3 code such as deu, aut, che or usa - got "${value}".`
+    );
+  }
+  return lower;
+}
+
+/**
+ * WHERE conditions for device and country.
+ *
+ * Both are optional and unset means unfiltered - every tool keeps returning all
+ * devices and all countries unless asked otherwise.
+ *
+ * Discover carries no device: the column is NULL on every DISCOVER row, so a
+ * device filter there would silently return nothing. That fails loudly instead.
+ */
+export function deviceCountryConditions(
+  device?: string,
+  country?: string,
+  searchType?: string
+): string[] {
+  const conditions: string[] = [];
+
+  if (device) {
+    if (searchType && searchType.toUpperCase() === "DISCOVER") {
+      throw new Error(
+        "Discover rows carry no device - the column is NULL for every Discover impression, so a device filter cannot match. Drop the device argument, or query a different surface."
+      );
+    }
+    conditions.push(`device = '${normaliseDevice(device)}'`);
+  }
+
+  if (country) {
+    conditions.push(`country = '${normaliseCountry(country)}'`);
+  }
+
+  return conditions;
+}
+
+/** Doubles single quotes, matching the escaping the other tools in this server use. */
+export function escapeSQLString(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/**
+ * Latest day present in the export.
+ *
+ * Anchoring ranges here instead of CURRENT_DATE() matters: the bulk export
+ * trails by two to three days, so a CURRENT_DATE()-based window silently
+ * includes empty days and drags period comparisons down with it. Same principle
+ * as the inline `(SELECT MAX(data_date) ...)` subqueries v4.1.1 introduced,
+ * resolved once per call so these tools can also label the window they used.
+ */
+export async function getLastExportDate(
+  ds: string,
+  runQuery: (sql: string, maxRows?: number) => Promise<{ rows: Record<string, unknown>[] }>
+): Promise<string> {
+  const result = await runQuery(
+    `SELECT MAX(data_date) AS last_day FROM \`${ds}.searchdata_url_impression\` LIMIT 1`,
+    1
+  );
+  const raw = result.rows[0]?.last_day as { value?: string } | string | undefined;
+  const value = typeof raw === "object" && raw !== null ? raw.value : raw;
+  if (!value) {
+    throw new Error(
+      `No data found in \`${ds}.searchdata_url_impression\`. Is the GSC bulk export set up for this dataset?`
+    );
+  }
+  return value;
+}

--- a/src/tools/gsc-shopping.ts
+++ b/src/tools/gsc-shopping.ts
@@ -1,0 +1,207 @@
+import { runQuery } from "./query.js";
+import { getConfig, validateIdentifier } from "../client.js";
+import {
+  AVG_POSITION_SQL,
+  GRANULARITY_TRUNC,
+  Granularity,
+  escapeSQLString,
+  getLastExportDate,
+} from "./gsc-shared.js";
+
+type QueryResult = { rows: Record<string, unknown>[]; totalRows: number; bytesProcessed: string };
+
+/**
+ * Organic shopping surfaces: free product listings, merchant listings and
+ * product snippets.
+ *
+ * These are search appearances, not search types - they live inside WEB rows,
+ * flagged by their own boolean columns. The GSC API exposes them only through
+ * the searchAppearance dimension, which cannot be combined with other
+ * groupings; here they are ordinary columns, so they can be crossed with url,
+ * query, device and date freely.
+ *
+ * A property that sells nothing returns zeros. That is an answer, not a bug,
+ * and the result says so explicitly instead of looking like a failed query.
+ */
+export const SHOPPING_APPEARANCES = {
+  organic_shopping: "is_organic_shopping",
+  merchant_listings: "is_merchant_listings",
+  product_snippets: "is_product_snippets",
+} as const;
+
+export type ShoppingAppearance = keyof typeof SHOPPING_APPEARANCES;
+
+export async function gscShopping(
+  days: number = 28,
+  appearance?: ShoppingAppearance,
+  granularity: Granularity = "week",
+  urlContains?: string,
+  topRows: number = 50,
+  dataset?: string
+): Promise<{
+  period: { startDate: string; endDate: string; days: number; anchoredTo: string };
+  overview: QueryResult;
+  dataAvailable: boolean;
+  note: string;
+  drilldown: {
+    appearance: ShoppingAppearance;
+    topUrls: QueryResult;
+    topQueries: QueryResult;
+    timeSeries: QueryResult | null;
+  } | null;
+}> {
+  const config = getConfig();
+  const ds = dataset || config.defaultDataset || "searchconsole";
+  validateIdentifier(ds, "dataset");
+
+  if (appearance && !(appearance in SHOPPING_APPEARANCES)) {
+    throw new Error(
+      `Unknown appearance "${appearance}". Allowed: ${Object.keys(SHOPPING_APPEARANCES).join(", ")}.`
+    );
+  }
+
+  const lastDay = await getLastExportDate(ds, runQuery);
+  const table = `\`${ds}.searchdata_url_impression\``;
+
+  const window = `data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days} DAY)
+      AND data_date <= DATE '${lastDay}'`;
+  const urlScope = urlContains ? `AND url LIKE '%${escapeSQLString(urlContains)}%'` : "";
+
+  const metricsFor = (name: string, column: string) => `
+      SUM(IF(${column}, clicks, 0)) AS ${name}_clicks,
+      SUM(IF(${column}, impressions, 0)) AS ${name}_impressions,
+      ROUND(SAFE_DIVIDE(
+        SUM(IF(${column}, clicks, 0)), SUM(IF(${column}, impressions, 0))
+      ) * 100, 2) AS ${name}_ctr_pct,
+      ROUND(SAFE_DIVIDE(
+        SUM(IF(${column}, sum_position, 0)), SUM(IF(${column}, impressions, 0))
+      ) + 1, 1) AS ${name}_avg_position,
+      COUNT(DISTINCT IF(${column}, url, NULL)) AS ${name}_urls,
+      COUNT(DISTINCT IF(${column}, query, NULL)) AS ${name}_queries`;
+
+  const overviewSQL = `
+    SELECT
+      ${metricsFor("organic_shopping", "is_organic_shopping")},
+      ${metricsFor("merchant_listings", "is_merchant_listings")},
+      ${metricsFor("product_snippets", "is_product_snippets")},
+      SUM(clicks) AS all_clicks,
+      SUM(impressions) AS all_impressions
+    FROM ${table}
+    WHERE ${window}
+      ${urlScope}
+    LIMIT 1
+  `;
+
+  const overview = await runQuery(overviewSQL, 1);
+  const row = overview.rows[0] || {};
+  const clicksOf = (name: string) => Number(row[`${name}_clicks`] ?? 0);
+  const impressionsOf = (name: string) => Number(row[`${name}_impressions`] ?? 0);
+  const totalShoppingImpressions =
+    impressionsOf("organic_shopping") +
+    impressionsOf("merchant_listings") +
+    impressionsOf("product_snippets");
+
+  const dataAvailable = totalShoppingImpressions > 0;
+  const present = (Object.keys(SHOPPING_APPEARANCES) as ShoppingAppearance[]).filter(
+    (name) => impressionsOf(name) > 0
+  );
+  const absent = (Object.keys(SHOPPING_APPEARANCES) as ShoppingAppearance[]).filter(
+    (name) => impressionsOf(name) === 0
+  );
+  const note = dataAvailable
+    ? `Present with impressions: ${present
+        .map((name) => `${name} (${clicksOf(name)} clicks)`)
+        .join(", ")}.` +
+      (absent.length
+        ? ` No impressions at all on: ${absent.join(", ")} - the property does not appear on ${
+            absent.length === 1 ? "that surface" : "those surfaces"
+          }. Do not read a figure from one appearance as evidence for another.`
+        : "")
+    : "No impressions on any organic shopping surface in this window. The property appears in neither free product listings, merchant listings nor product snippets - typical for a site that sells nothing. Report this as a finding, not as missing data.";
+
+  let drilldown: Awaited<ReturnType<typeof gscShopping>>["drilldown"] = null;
+  if (appearance) {
+    const column = SHOPPING_APPEARANCES[appearance];
+    const flagScope = `AND ${column}`;
+    const limit = Math.min(topRows, 500);
+
+    const topUrlsSQL = `
+      SELECT
+        url,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+        ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+        COUNT(DISTINCT query) AS queries
+      FROM ${table}
+      WHERE ${window}
+        ${flagScope}
+        ${urlScope}
+      GROUP BY url
+      ORDER BY clicks DESC
+      LIMIT ${limit}
+    `;
+
+    const topQueriesSQL = `
+      SELECT
+        query,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+        ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+        COUNT(DISTINCT url) AS urls
+      FROM ${table}
+      WHERE ${window}
+        ${flagScope}
+        AND query IS NOT NULL
+        ${urlScope}
+      GROUP BY query
+      ORDER BY clicks DESC
+      LIMIT ${limit}
+    `;
+
+    let timeSeriesSQL: string | null = null;
+    if (granularity !== "none") {
+      timeSeriesSQL = `
+        SELECT
+          DATE_TRUNC(data_date, ${GRANULARITY_TRUNC[granularity]}) AS bucket,
+          SUM(clicks) AS clicks,
+          SUM(impressions) AS impressions,
+          ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+          ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+          COUNT(DISTINCT url) AS urls
+        FROM ${table}
+        WHERE ${window}
+          ${flagScope}
+          ${urlScope}
+        GROUP BY bucket
+        ORDER BY bucket
+        LIMIT 400
+      `;
+    }
+
+    const [topUrls, topQueries, timeSeries] = await Promise.all([
+      runQuery(topUrlsSQL, limit),
+      runQuery(topQueriesSQL, limit),
+      timeSeriesSQL ? runQuery(timeSeriesSQL, 400) : Promise.resolve(null),
+    ]);
+
+    drilldown = { appearance, topUrls, topQueries, timeSeries };
+  }
+
+  const start = new Date(lastDay);
+  start.setUTCDate(start.getUTCDate() - days + 1);
+
+  return {
+    period: {
+      startDate: start.toISOString().split("T")[0],
+      endDate: lastDay,
+      days,
+      anchoredTo: `latest day in the export (${lastDay}), not today`,
+    },
+    overview,
+    dataAvailable,
+    note,
+    drilldown,
+  };
+}


### PR DESCRIPTION
Rebased onto current `main` (v4.1.1), as asked. Thanks for the credit in 4ad21b0 and the changelog — and no argument on anchoring windows to the export's latest `data_date`; your version of that is the better one and it's already in here by inheritance.

The `+ 1` fix is gone from this branch entirely. `dist/` is out of the diff. What's left is 8 source files, ~1,230 lines, no changes to any existing tool.

### Five commits, one tool each

Each commit typechecks on its own against this branch's parent, so you can take them one at a time or cherry-pick in any order after the first.

| Commit | Tool | What it answers |
|---|---|---|
| 1 | `gsc_query_count` | How many distinct queries a site, section or URL is visible for, by position group, vs the previous period. The API answers this from one 1,000-row page, so above that ceiling it returns a floor, not a count. Anonymised share read from `is_anonymized_query` instead of inferred from a click gap. |
| 2 | `gsc_discover` | Discover clicks, impressions, CTR, share of surfaces, time series, top URLs, country split. Page-based, own `is_anonymized_discover` flag. |
| 3 | `gsc_click_curve` | CTR per rank measured on the property's own data. Segment by device, country, surface, or branded vs non-branded. |
| 4 | `gsc_shopping` | Free product listings, merchant listings, product snippets — as boolean columns inside WEB rows, so they cross freely with url, query, device and date, unlike the API's `searchAppearance`. |
| 5 | `gsc_image_search` | Images clicks, impressions, CTR, position, top pages and queries, plus the `is_amp_image_result` slice. |

Commit 1 also adds `src/tools/gsc-shared.ts`, the SQL fragments these five have in common: the `+ 1` position expression, position buckets, granularity mapping, search-type and device/country normalisation, and the last-export-day lookup. Only the five new tools import it — I did not retrofit it onto anything you already have.

### On the click curve

The number from the thread, for the record: **3.54% CTR at position 1** on the property I measured, against the **28.5%** in `gsc_ctr_benchmark`'s hardcoded table. Factor of eight. Against the borrowed curve, nearly every page on that site reads as underperforming.

The method is a ratio of sums, never a mean of ratios: aggregate to `(url, query)`, take that pair's average position, round to a rank, then divide summed clicks by summed impressions per rank. Ranks under `min_impressions_per_rank` are dropped rather than reported as noise, and the result states how many clicks the curve cannot cover, because anonymized rows carry no position.

`segment_by=branded` with a `brand_pattern` is the split I'd argue matters most — branded queries cluster at the top and inflate a blended curve exactly where it gets consumed.

Wiring `gsc_ctr_benchmark` against this curve is **not** in this PR, as agreed. It changes an existing tool's output and gets its own.

### Two things worth your judgement

**The date-anchoring idiom.** 4ad21b0 inlines `(SELECT MAX(data_date) FROM ...)` into each query. These five instead call `getLastExportDate()` once per tool call, because they report the window back to the caller (`"anchored to latest day in the export (<last data_date>), not today"`). Same semantics, one extra partition-column-only query per call. If you'd rather have a single idiom across the repo, say the word and I'll switch them to the inline form.

**`POSITION_CAVEAT`.** I appended it to the four tools that report `avg_position` (`gsc_query_count`, `gsc_click_curve`, `gsc_shopping`, `gsc_image_search`) and left it off `gsc_discover`, which has no ranking position. Shout if you'd scope that differently.

### Deliberately not included

- `dist/` — you'll want to rebuild it yourself.
- `package.json` version bump and the changelog entry — yours to write.
- Any modification to an existing tool.
- The per-dataset `BIGQUERY_DATASET_LOCATIONS` work from my other branch. Separate concern, separate PR if you want it.

#1 stays open until you close it.
