### PR TITLE
DRAFT (do not merge yet, stacked on #2): wire gsc_ctr_benchmark to the measured click curve

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server for BigQuery that lets you ask Claude questions about your search and analytics data warehouse and get real answers. Not raw query results. Actual analysis with verdicts and recommendations.
 
-33 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
+34 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
 
 > **Full setup guide with screenshots:** [suganthan.com/blog/bigquery-mcp-server/](https://suganthan.com/blog/bigquery-mcp-server/)
 >
@@ -113,9 +113,9 @@ Your service account needs three IAM roles: **BigQuery Data Editor**, **BigQuery
 >
 > **Want the GA4 + GSC blending tools too?** Add the GA4 BigQuery export and one extra environment variable (`BIGQUERY_GA4_DATASET`). Full walkthrough: [GA4 + GSC in BigQuery setup guide](https://suganthan.com/blog/google-analytics-bigquery-mcp-server/).
 
-## All 33 tools
+## All 34 tools
 
-### BigQuery exclusive (9)
+### BigQuery exclusive (10)
 
 These use BigQuery capabilities the Search Console API simply doesn't have.
 
@@ -130,6 +130,7 @@ These use BigQuery capabilities the Search Console API simply doesn't have.
 | `gsc_intent_breakdown` | Classify all queries by search intent: informational, transactional, commercial, navigational. |
 | `gsc_ngrams` | Extract recurring terms from queries. Find themes your content should cover. |
 | `gsc_new_keywords` | Queries appearing in recent data that weren't present before. |
+| `gsc_query_count` | How many distinct queries a site, section or single URL is visible for, by position group, over time, against the previous period. Counts the whole export instead of a 1,000-row page, and reads the anonymised share from `is_anonymized_query` instead of inferring it. |
 
 ### GSC analysis (12)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server for BigQuery that lets you ask Claude questions about your search and analytics data warehouse and get real answers. Not raw query results. Actual analysis with verdicts and recommendations.
 
-36 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
+37 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
 
 > **Full setup guide with screenshots:** [suganthan.com/blog/bigquery-mcp-server/](https://suganthan.com/blog/bigquery-mcp-server/)
 >
@@ -113,9 +113,9 @@ Your service account needs three IAM roles: **BigQuery Data Editor**, **BigQuery
 >
 > **Want the GA4 + GSC blending tools too?** Add the GA4 BigQuery export and one extra environment variable (`BIGQUERY_GA4_DATASET`). Full walkthrough: [GA4 + GSC in BigQuery setup guide](https://suganthan.com/blog/google-analytics-bigquery-mcp-server/).
 
-## All 36 tools
+## All 37 tools
 
-### BigQuery exclusive (12)
+### BigQuery exclusive (13)
 
 These use BigQuery capabilities the Search Console API simply doesn't have.
 
@@ -133,6 +133,7 @@ These use BigQuery capabilities the Search Console API simply doesn't have.
 | `gsc_query_count` | How many distinct queries a site, section or single URL is visible for, by position group, over time, against the previous period. Counts the whole export instead of a 1,000-row page, and reads the anonymised share from `is_anonymized_query` instead of inferring it. |
 | `gsc_discover` | Google Discover performance: clicks, impressions, CTR, share of all surfaces, time series, top URLs, country split. Page-based, with its own `is_anonymized_discover` flag. |
 | `gsc_click_curve` | Your own click curve: CTR per rank measured on your data, not borrowed from a study. Segment by device, country, surface, or branded vs non-branded. Also reports the clicks it cannot cover. |
+| `gsc_shopping` | Organic shopping surfaces: free product listings, merchant listings, product snippets. Search appearances inside WEB rows, so they cross freely with url, query, device and date - unlike the API's `searchAppearance` dimension. |
 
 ### GSC analysis (12)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server for BigQuery that lets you ask Claude questions about your search and analytics data warehouse and get real answers. Not raw query results. Actual analysis with verdicts and recommendations.
 
-37 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
+38 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
 
 > **Full setup guide with screenshots:** [suganthan.com/blog/bigquery-mcp-server/](https://suganthan.com/blog/bigquery-mcp-server/)
 >
@@ -113,9 +113,9 @@ Your service account needs three IAM roles: **BigQuery Data Editor**, **BigQuery
 >
 > **Want the GA4 + GSC blending tools too?** Add the GA4 BigQuery export and one extra environment variable (`BIGQUERY_GA4_DATASET`). Full walkthrough: [GA4 + GSC in BigQuery setup guide](https://suganthan.com/blog/google-analytics-bigquery-mcp-server/).
 
-## All 37 tools
+## All 38 tools
 
-### BigQuery exclusive (13)
+### BigQuery exclusive (14)
 
 These use BigQuery capabilities the Search Console API simply doesn't have.
 
@@ -134,6 +134,7 @@ These use BigQuery capabilities the Search Console API simply doesn't have.
 | `gsc_discover` | Google Discover performance: clicks, impressions, CTR, share of all surfaces, time series, top URLs, country split. Page-based, with its own `is_anonymized_discover` flag. |
 | `gsc_click_curve` | Your own click curve: CTR per rank measured on your data, not borrowed from a study. Segment by device, country, surface, or branded vs non-branded. Also reports the clicks it cannot cover. |
 | `gsc_shopping` | Organic shopping surfaces: free product listings, merchant listings, product snippets. Search appearances inside WEB rows, so they cross freely with url, query, device and date - unlike the API's `searchAppearance` dimension. |
+| `gsc_image_search` | Google Images: clicks, impressions, CTR, position, share of all surfaces, top pages and queries, AMP image results. `url` is the hosting page, not the image file. |
 
 ### GSC analysis (12)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server for BigQuery that lets you ask Claude questions about your search and analytics data warehouse and get real answers. Not raw query results. Actual analysis with verdicts and recommendations.
 
-34 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
+35 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
 
 > **Full setup guide with screenshots:** [suganthan.com/blog/bigquery-mcp-server/](https://suganthan.com/blog/bigquery-mcp-server/)
 >
@@ -113,9 +113,9 @@ Your service account needs three IAM roles: **BigQuery Data Editor**, **BigQuery
 >
 > **Want the GA4 + GSC blending tools too?** Add the GA4 BigQuery export and one extra environment variable (`BIGQUERY_GA4_DATASET`). Full walkthrough: [GA4 + GSC in BigQuery setup guide](https://suganthan.com/blog/google-analytics-bigquery-mcp-server/).
 
-## All 34 tools
+## All 35 tools
 
-### BigQuery exclusive (10)
+### BigQuery exclusive (11)
 
 These use BigQuery capabilities the Search Console API simply doesn't have.
 
@@ -131,6 +131,7 @@ These use BigQuery capabilities the Search Console API simply doesn't have.
 | `gsc_ngrams` | Extract recurring terms from queries. Find themes your content should cover. |
 | `gsc_new_keywords` | Queries appearing in recent data that weren't present before. |
 | `gsc_query_count` | How many distinct queries a site, section or single URL is visible for, by position group, over time, against the previous period. Counts the whole export instead of a 1,000-row page, and reads the anonymised share from `is_anonymized_query` instead of inferring it. |
+| `gsc_discover` | Google Discover performance: clicks, impressions, CTR, share of all surfaces, time series, top URLs, country split. Page-based, with its own `is_anonymized_discover` flag. |
 
 ### GSC analysis (12)
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The same analysis tools from the [GSC MCP server](https://github.com/Suganthan-M
 | `gsc_cannibalisation` | Keywords where multiple pages compete against each other |
 | `gsc_traffic_drops` | What lost traffic, and whether it's a ranking loss, CTR collapse, or demand decline |
 | `gsc_topic_cluster` | Aggregated performance for all pages matching a URL path pattern |
-| `gsc_ctr_benchmark` | Your actual CTR per position vs industry benchmarks |
+| `gsc_ctr_benchmark` | Your actual CTR per page vs your own measured click curve, falling back to the study table only for ranks you cannot measure. Every row says which it was judged against. |
 | `gsc_alerts` | Position drops, CTR collapses, click losses, disappeared pages. Severity rated |
 | `gsc_content_recommendations` | Prioritised actions: pages to update, content to create, pages to consolidate |
 | `gsc_report` | Full markdown performance report |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server for BigQuery that lets you ask Claude questions about your search and analytics data warehouse and get real answers. Not raw query results. Actual analysis with verdicts and recommendations.
 
-35 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
+36 tools. GA4 + GSC revenue attribution. Generative AI conversation-query detection. ML forecasting. Anomaly detection. Anonymous query analysis. Free and open source.
 
 > **Full setup guide with screenshots:** [suganthan.com/blog/bigquery-mcp-server/](https://suganthan.com/blog/bigquery-mcp-server/)
 >
@@ -113,9 +113,9 @@ Your service account needs three IAM roles: **BigQuery Data Editor**, **BigQuery
 >
 > **Want the GA4 + GSC blending tools too?** Add the GA4 BigQuery export and one extra environment variable (`BIGQUERY_GA4_DATASET`). Full walkthrough: [GA4 + GSC in BigQuery setup guide](https://suganthan.com/blog/google-analytics-bigquery-mcp-server/).
 
-## All 35 tools
+## All 36 tools
 
-### BigQuery exclusive (11)
+### BigQuery exclusive (12)
 
 These use BigQuery capabilities the Search Console API simply doesn't have.
 
@@ -132,6 +132,7 @@ These use BigQuery capabilities the Search Console API simply doesn't have.
 | `gsc_new_keywords` | Queries appearing in recent data that weren't present before. |
 | `gsc_query_count` | How many distinct queries a site, section or single URL is visible for, by position group, over time, against the previous period. Counts the whole export instead of a 1,000-row page, and reads the anonymised share from `is_anonymized_query` instead of inferring it. |
 | `gsc_discover` | Google Discover performance: clicks, impressions, CTR, share of all surfaces, time series, top URLs, country split. Page-based, with its own `is_anonymized_discover` flag. |
+| `gsc_click_curve` | Your own click curve: CTR per rank measured on your data, not borrowed from a study. Segment by device, country, surface, or branded vs non-branded. Also reports the clicks it cannot cover. |
 
 ### GSC analysis (12)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import { gscGenaiConversationQueries } from "./tools/gsc-genai-conversation-quer
 // Export-only surfaces and counts the Search Console API cannot return.
 import { gscQueryCount } from "./tools/gsc-query-count.js";
 import { gscDiscover } from "./tools/gsc-discover.js";
+import { gscClickCurve } from "./tools/gsc-click-curve.js";
 
 const server = new McpServer({
   name: "bigquery-mcp",
@@ -859,10 +860,35 @@ server.tool(
   }
 );
 
+// The click curve, measured on this property instead of borrowed from a study
+server.tool(
+  "gsc_click_curve",
+  "Build the click curve from your own data: CTR per ranking position, measured instead of borrowed from a study. Aggregates to (url, query) pairs, takes each pair's average position, rounds it to a rank, then divides summed clicks by summed impressions per rank. Segment by device, country, search_type, or branded vs non-branded with a brand_pattern - the branded split matters most, because branded queries inflate a blended curve at the top. Also reports how many clicks the curve cannot cover, because anonymized rows carry no position." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX + POSITION_CAVEAT,
+  {
+    days: z.number().default(90).describe("Number of days to analyse. Longer is better here: the curve needs volume per rank."),
+    max_position: z.number().default(20).describe("Highest rank to include"),
+    min_impressions_per_rank: z.number().default(100).describe("Drop ranks below this many impressions instead of reporting noise"),
+    segment_by: z.enum(["none", "device", "country", "search_type", "branded"]).default("none").describe("Split the curve by this dimension"),
+    brand_pattern: z.string().optional().describe("Regex for branded queries, required when segment_by is branded, e.g. yourbrand"),
+    search_type: z.enum(["WEB", "IMAGE", "VIDEO", "NEWS", "GOOGLE_NEWS"]).default("WEB").describe("Surface to measure. Ignored when segment_by is search_type."),
+    url_contains: z.string().optional().describe("Restrict to URLs containing this string, e.g. to get a curve for one section"),
+    dataset: z.string().optional().describe("BigQuery dataset containing GSC data"),
+  },
+  async ({ days, max_position, min_impressions_per_rank, segment_by, brand_pattern, search_type, url_contains, dataset }) => {
+    try {
+      const results = await gscClickCurve(days, max_position, min_impressions_per_rank, segment_by, brand_pattern, search_type, url_contains, dataset);
+      const wrapped = withMeta(results, "gsc_click_curve", { days, max_position, min_impressions_per_rank, segment_by, brand_pattern, search_type, url_contains, dataset });
+      return { content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }] };
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("BigQuery MCP server v4.1.1 running on stdio (35 tools)");
+  console.error("BigQuery MCP server v4.1.1 running on stdio (36 tools)");
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { gscGenaiConversationQueries } from "./tools/gsc-genai-conversation-quer
 import { gscQueryCount } from "./tools/gsc-query-count.js";
 import { gscDiscover } from "./tools/gsc-discover.js";
 import { gscClickCurve } from "./tools/gsc-click-curve.js";
+import { gscShopping } from "./tools/gsc-shopping.js";
 
 const server = new McpServer({
   name: "bigquery-mcp",
@@ -885,10 +886,33 @@ server.tool(
   }
 );
 
+// Organic shopping surfaces, as columns rather than the API's searchAppearance
+server.tool(
+  "gsc_shopping",
+  "Organic shopping surfaces: free product listings (is_organic_shopping), merchant listings (is_merchant_listings) and product snippets (is_product_snippets). These are search appearances inside WEB rows, so unlike the API searchAppearance dimension they can be crossed with url, query, device and date freely. Without an appearance argument it returns all three side by side; pass one to drill into its top URLs, top queries and time series. A property that sells nothing returns zeros - that is a finding, and the note field says so." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX + POSITION_CAVEAT,
+  {
+    days: z.number().default(28).describe("Number of days to analyse"),
+    appearance: z.enum(["organic_shopping", "merchant_listings", "product_snippets"]).optional().describe("Drill into one appearance. Omit for the overview of all three."),
+    granularity: z.enum(["none", "day", "week", "month"]).default("week").describe("Bucket size for the drilldown time series"),
+    url_contains: z.string().optional().describe("Restrict to URLs containing this string"),
+    top_rows: z.number().default(50).describe("How many URLs and queries to return in the drilldown"),
+    dataset: z.string().optional().describe("BigQuery dataset containing GSC data"),
+  },
+  async ({ days, appearance, granularity, url_contains, top_rows, dataset }) => {
+    try {
+      const results = await gscShopping(days, appearance, granularity, url_contains, top_rows, dataset);
+      const wrapped = withMeta(results, "gsc_shopping", { days, appearance, granularity, url_contains, top_rows, dataset });
+      return { content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }] };
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("BigQuery MCP server v4.1.1 running on stdio (36 tools)");
+  console.error("BigQuery MCP server v4.1.1 running on stdio (37 tools)");
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -376,16 +376,19 @@ server.tool(
 // 15. GSC CTR vs Benchmark
 server.tool(
   "gsc_ctr_benchmark",
-  "Compare your actual CTR per page against industry benchmarks by position. Flags pages significantly underperforming for their ranking position with verdicts." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX + POSITION_CAVEAT,
+  "Compare your actual CTR per page against a benchmark curve by position, with verdicts for pages underperforming their ranking. The benchmark is your own click curve measured from the export; the published study table is used only for ranks your property has too little data to measure, and every row reports which of the two it was judged against via benchmark_source, and how many impressions stood behind that rank via benchmark_rank_impressions. Pass benchmark=study to judge against the study table alone." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX + POSITION_CAVEAT,
   {
     days: z.number().default(28).describe("Number of days to analyse"),
     min_impressions: z.number().default(200).describe("Minimum impressions threshold"),
+    benchmark: z.enum(["measured", "study"]).default("measured").describe("Judge against your own measured click curve (default) or against the published study table"),
+    curve_days: z.number().default(90).describe("Window used to build the measured curve. Longer is steadier but scans more; ignored when benchmark=study."),
+    min_impressions_per_rank: z.number().default(100).describe("Ranks with fewer impressions than this fall back to the study curve instead of reporting noise"),
     dataset: z.string().optional().describe("BigQuery dataset containing GSC data"),
   },
-  async ({ days, min_impressions, dataset }) => {
+  async ({ days, min_impressions, benchmark, curve_days, min_impressions_per_rank, dataset }) => {
     try {
-      const results = await gscCtrBenchmark(days, min_impressions, dataset);
-      const wrapped = withMeta(results, "gsc_ctr_benchmark", { days, min_impressions });
+      const results = await gscCtrBenchmark(days, min_impressions, benchmark, curve_days, min_impressions_per_rank, dataset);
+      const wrapped = withMeta(results, "gsc_ctr_benchmark", { days, min_impressions, benchmark, curve_days, min_impressions_per_rank });
       return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,8 @@ import { ga4GscPositionValue } from "./tools/ga4-gsc-position-value.js";
 import { ga4GscBrandedPerformance } from "./tools/ga4-gsc-branded-performance.js";
 // v4.1 generative AI tools — AI Mode conversation exhaust in the query table.
 import { gscGenaiConversationQueries } from "./tools/gsc-genai-conversation-queries.js";
+// Export-only surfaces and counts the Search Console API cannot return.
+import { gscQueryCount } from "./tools/gsc-query-count.js";
 
 const server = new McpServer({
   name: "bigquery-mcp",
@@ -806,10 +808,38 @@ server.tool(
   }
 );
 
+// Query counting across the whole export, not a 1,000-row API page
+server.tool(
+  "gsc_query_count",
+  "Count how many distinct queries a property, a section or a single URL is visible for, split by position group (1-3, 4-10, 11-20, 21-50, 51+), against the previous period of equal length. Scope with url or url_contains, add a time series with granularity, narrow with min_position/max_position, rank pages with top_pages. Unlike the API version this counts the whole export instead of a 1,000-row page, and reads the anonymized share from is_anonymized_query rather than inferring it from a click gap." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX + POSITION_CAVEAT,
+  {
+    days: z.number().default(28).describe("Number of days to analyse"),
+    url: z.string().optional().describe("Count only queries for this exact URL"),
+    url_contains: z.string().optional().describe("Count only queries for URLs containing this string, e.g. /guides/"),
+    granularity: z.enum(["none", "day", "week", "month"]).default("none").describe("Add a time series of distinct query counts"),
+    min_position: z.number().optional().describe("Only count queries at this average position or worse (e.g. 4)"),
+    max_position: z.number().optional().describe("Only count queries at this average position or better (e.g. 10)"),
+    search_type: z.enum(["WEB", "IMAGE", "VIDEO", "NEWS", "GOOGLE_NEWS"]).default("WEB").describe("Surface to count. Discover has no queries; use gsc_discover."),
+    top_pages: z.number().optional().describe("Also rank this many pages by query count"),
+    device: z.enum(["MOBILE", "DESKTOP", "TABLET"]).optional().describe("Restrict to one device. Omit for all devices, which is the default."),
+    country: z.string().optional().describe("Restrict to one country as an ISO-3166-1 alpha-3 code, e.g. usa, gbr, deu. Omit for all countries, which is the default."),
+    dataset: z.string().optional().describe("BigQuery dataset containing GSC data"),
+  },
+  async ({ days, url, url_contains, granularity, min_position, max_position, search_type, top_pages, device, country, dataset }) => {
+    try {
+      const results = await gscQueryCount(days, url, url_contains, granularity, min_position, max_position, search_type, top_pages, device, country, dataset);
+      const wrapped = withMeta(results, "gsc_query_count", { days, url, url_contains, granularity, min_position, max_position, search_type, top_pages, device, country, dataset });
+      return { content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }] };
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("BigQuery MCP server v4.1.1 running on stdio (33 tools)");
+  console.error("BigQuery MCP server v4.1.1 running on stdio (34 tools)");
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import { gscQueryCount } from "./tools/gsc-query-count.js";
 import { gscDiscover } from "./tools/gsc-discover.js";
 import { gscClickCurve } from "./tools/gsc-click-curve.js";
 import { gscShopping } from "./tools/gsc-shopping.js";
+import { gscImageSearch } from "./tools/gsc-image-search.js";
 
 const server = new McpServer({
   name: "bigquery-mcp",
@@ -909,10 +910,32 @@ server.tool(
   }
 );
 
+// Google Images, including the AMP image slice
+server.tool(
+  "gsc_image_search",
+  "Google Images performance from the export: clicks, impressions, CTR, average position, share of all surfaces, time series, top pages, top queries, device and country split, plus the AMP-image-result slice. Unlike Discover, image search does carry queries. Note that url is the page hosting the image, not the image file - the export has no image-level dimension." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX + POSITION_CAVEAT,
+  {
+    days: z.number().default(28).describe("Number of days to analyse"),
+    granularity: z.enum(["none", "day", "week", "month"]).default("week").describe("Bucket size for the time series"),
+    url_contains: z.string().optional().describe("Restrict to URLs containing this string"),
+    top_rows: z.number().default(50).describe("How many pages and queries to return"),
+    dataset: z.string().optional().describe("BigQuery dataset containing GSC data"),
+  },
+  async ({ days, granularity, url_contains, top_rows, dataset }) => {
+    try {
+      const results = await gscImageSearch(days, granularity, url_contains, top_rows, dataset);
+      const wrapped = withMeta(results, "gsc_image_search", { days, granularity, url_contains, top_rows, dataset });
+      return { content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }] };
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("BigQuery MCP server v4.1.1 running on stdio (37 tools)");
+  console.error("BigQuery MCP server v4.1.1 running on stdio (38 tools)");
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import { ga4GscBrandedPerformance } from "./tools/ga4-gsc-branded-performance.js
 import { gscGenaiConversationQueries } from "./tools/gsc-genai-conversation-queries.js";
 // Export-only surfaces and counts the Search Console API cannot return.
 import { gscQueryCount } from "./tools/gsc-query-count.js";
+import { gscDiscover } from "./tools/gsc-discover.js";
 
 const server = new McpServer({
   name: "bigquery-mcp",
@@ -836,10 +837,32 @@ server.tool(
   }
 );
 
+// Google Discover: page-based, no query dimension, its own anonymisation flag
+server.tool(
+  "gsc_discover",
+  "Google Discover performance from the export: clicks, impressions, CTR, its share of all surfaces, a time series, top URLs, device and country split. Discover is page-based, so nothing groups by query, and its anonymisation is tracked separately via is_anonymized_discover." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX,
+  {
+    days: z.number().default(28).describe("Number of days to analyse"),
+    granularity: z.enum(["none", "day", "week", "month"]).default("week").describe("Bucket size for the time series"),
+    url_contains: z.string().optional().describe("Restrict to URLs containing this string"),
+    top_urls: z.number().default(50).describe("How many top URLs to return"),
+    dataset: z.string().optional().describe("BigQuery dataset containing GSC data"),
+  },
+  async ({ days, granularity, url_contains, top_urls, dataset }) => {
+    try {
+      const results = await gscDiscover(days, granularity, url_contains, top_urls, dataset);
+      const wrapped = withMeta(results, "gsc_discover", { days, granularity, url_contains, top_urls, dataset });
+      return { content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }] };
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("BigQuery MCP server v4.1.1 running on stdio (34 tools)");
+  console.error("BigQuery MCP server v4.1.1 running on stdio (35 tools)");
 }
 
 main().catch((error) => {

--- a/src/tools/gsc-click-curve.ts
+++ b/src/tools/gsc-click-curve.ts
@@ -1,0 +1,150 @@
+import { runQuery } from "./query.js";
+import { getConfig, validateIdentifier } from "../client.js";
+import {
+  AVG_POSITION_SQL,
+  normaliseSearchType,
+  escapeSQLString,
+  getLastExportDate,
+} from "./gsc-shared.js";
+
+type QueryResult = { rows: Record<string, unknown>[]; totalRows: number; bytesProcessed: string };
+
+export type CurveSegment = "none" | "device" | "country" | "search_type" | "branded";
+
+/**
+ * Your own click curve: CTR by ranking position, measured on your data.
+ *
+ * Every "expected CTR by position" table in an SEO tool is somebody else's
+ * average - usually a study across unrelated sites. This builds the curve from
+ * the export: aggregate to (url, query), take that pair's average position,
+ * round it to a rank, then sum clicks and impressions per rank. CTR is the
+ * ratio of those sums, never an average of ratios, so high-volume pairs carry
+ * the weight they should.
+ *
+ * With segment_by="branded" and a brand_pattern, the branded and non-branded
+ * curves come back separately - the split that matters most, because branded
+ * queries inflate a blended curve at the top and make everything else look
+ * like it underperforms.
+ */
+export async function gscClickCurve(
+  days: number = 90,
+  maxPosition: number = 20,
+  minImpressionsPerRank: number = 100,
+  segmentBy: CurveSegment = "none",
+  brandPattern?: string,
+  searchType: string = "WEB",
+  urlContains?: string,
+  dataset?: string
+): Promise<{
+  period: { startDate: string; endDate: string; days: number; anchoredTo: string };
+  method: string;
+  curve: QueryResult;
+  coverage: QueryResult;
+}> {
+  const config = getConfig();
+  const ds = dataset || config.defaultDataset || "searchconsole";
+  validateIdentifier(ds, "dataset");
+  const type = normaliseSearchType(searchType);
+
+  if (type === "DISCOVER") {
+    throw new Error(
+      "Discover has no ranking positions, so there is no click curve to build. Use gsc_discover instead."
+    );
+  }
+  if (segmentBy === "branded" && !brandPattern) {
+    throw new Error(
+      'segment_by="branded" needs brand_pattern, e.g. "homeandsmart" or "brand|brandname".'
+    );
+  }
+
+  const lastDay = await getLastExportDate(ds, runQuery);
+  const table = `\`${ds}.searchdata_url_impression\``;
+
+  const window = `data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days} DAY)
+      AND data_date <= DATE '${lastDay}'`;
+  const urlScope = urlContains ? `AND url LIKE '%${escapeSQLString(urlContains)}%'` : "";
+
+  let segmentExpr = "'all'";
+  if (segmentBy === "device") segmentExpr = "device";
+  if (segmentBy === "country") segmentExpr = "country";
+  if (segmentBy === "search_type") segmentExpr = "search_type";
+  if (segmentBy === "branded") {
+    segmentExpr = `IF(REGEXP_CONTAINS(query, r'(?i)${escapeSQLString(brandPattern!)}'), 'branded', 'non-branded')`;
+  }
+
+  // search_type stays unfiltered when it is the segment, otherwise it is pinned.
+  const typeScope = segmentBy === "search_type" ? "" : `AND search_type = '${type}'`;
+
+  const curveSQL = `
+    WITH per_pair AS (
+      SELECT
+        ${segmentExpr} AS segment,
+        url,
+        query,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ${AVG_POSITION_SQL} AS position
+      FROM ${table}
+      WHERE ${window}
+        AND query IS NOT NULL
+        ${typeScope}
+        ${urlScope}
+      GROUP BY segment, url, query
+    ),
+    ranked AS (
+      SELECT
+        segment,
+        CAST(ROUND(position) AS INT64) AS rank,
+        clicks,
+        impressions
+      FROM per_pair
+    )
+    SELECT
+      segment,
+      rank AS position,
+      SUM(impressions) AS impressions,
+      SUM(clicks) AS clicks,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 3) AS ctr_pct,
+      COUNT(*) AS url_query_pairs
+    FROM ranked
+    WHERE rank BETWEEN 1 AND ${maxPosition}
+    GROUP BY segment, rank
+    HAVING impressions >= ${minImpressionsPerRank}
+    ORDER BY segment, position
+    LIMIT 2000
+  `;
+
+  // What the curve does NOT cover, stated rather than left implicit: anonymized
+  // rows carry no query and no position, so they can never enter it.
+  const coverageSQL = `
+    SELECT
+      SUM(clicks) AS total_clicks,
+      SUM(IF(is_anonymized_query, clicks, 0)) AS anonymized_clicks,
+      ROUND(SAFE_DIVIDE(SUM(IF(is_anonymized_query, clicks, 0)), SUM(clicks)) * 100, 2)
+        AS anonymized_clicks_share_pct,
+      COUNT(DISTINCT query) AS distinct_queries
+    FROM ${table}
+    WHERE ${window}
+      ${typeScope}
+      ${urlScope}
+    LIMIT 1
+  `;
+
+  const [curve, coverage] = await Promise.all([runQuery(curveSQL, 2000), runQuery(coverageSQL, 1)]);
+
+  const start = new Date(lastDay);
+  start.setUTCDate(start.getUTCDate() - days + 1);
+
+  return {
+    period: {
+      startDate: start.toISOString().split("T")[0],
+      endDate: lastDay,
+      days,
+      anchoredTo: `latest day in the export (${lastDay}), not today`,
+    },
+    method:
+      "CTR per rank = SUM(clicks) / SUM(impressions) over (url, query) pairs whose average position rounds to that rank. Average position uses sum_position/impressions + 1, because sum_position is zero-based. Ranks below min_impressions_per_rank are dropped rather than reported as noise.",
+    curve,
+    coverage,
+  };
+}

--- a/src/tools/gsc-ctr-benchmark.ts
+++ b/src/tools/gsc-ctr-benchmark.ts
@@ -1,14 +1,74 @@
 import { runQuery } from "./query.js";
 import { getConfig, validateIdentifier } from "../client.js";
+import { measuredCurveCTEs, studyBenchmarkCaseSQL } from "./gsc-shared.js";
 
+export type BenchmarkSource = "measured" | "study";
+
+/**
+ * CTR per page against a benchmark curve.
+ *
+ * The benchmark defaults to the property's own click curve, measured from the
+ * export, with the published study table used only for ranks the property has
+ * too little data to measure. Pass benchmark="study" to force the old
+ * behaviour.
+ *
+ * Why the default changed: the study numbers are averages over unrelated sites.
+ * On the property this was measured against, position 1 carried a 3.54% CTR
+ * against the table's 28.5%. Judged against that, essentially every page came
+ * back as "significantly below benchmark" - a verdict about the reference, not
+ * about the page.
+ *
+ * Three caveats, all of them visible in the output rather than buried:
+ *
+ * 1. The curve is built at (url, query) level while the verdict is applied to a
+ *    page's blended position across all its queries. A page with an unusual
+ *    query mix sits against a rank that does not describe it exactly. Still far
+ *    closer than a foreign study, but not a per-query judgement.
+ * 2. A measured curve is not necessarily monotonic. On the reference property
+ *    rank 2 came out above rank 1 (4.08% against 3.73%), because the query mix
+ *    differs between ranks. The curve is left as measured rather than smoothed
+ *    into the shape a curve is "supposed" to have - the whole point is to report
+ *    this property, not an idealised one.
+ * 3. If the dataset holds less history than curveDays, the curve quietly uses
+ *    what exists, and a short window makes a thinner curve. Every row therefore
+ *    carries benchmark_rank_impressions: how much data stood behind the rank it
+ *    was judged against.
+ */
 export async function gscCtrBenchmark(
   days: number = 28,
   minImpressions: number = 200,
+  benchmark: BenchmarkSource = "measured",
+  curveDays: number = 90,
+  minImpressionsPerRank: number = 100,
   dataset?: string
 ): Promise<{ rows: Record<string, unknown>[]; totalRows: number; bytesProcessed: string }> {
   const config = getConfig();
   const ds = dataset || config.defaultDataset || "searchconsole";
   validateIdentifier(ds, "dataset");
+
+  const studyCase = studyBenchmarkCaseSQL("page_metrics.avg_position");
+
+  // benchmark="study" keeps the pre-existing behaviour and, more to the point,
+  // skips the curve CTE entirely so the query still scans only `days`.
+  const benchmarkCTE =
+    benchmark === "measured"
+      ? `${measuredCurveCTEs(ds, Math.max(days, curveDays), minImpressionsPerRank)},\n    `
+      : "";
+
+  const benchmarkSelect =
+    benchmark === "measured"
+      ? `ROUND(COALESCE(curve.measured_ctr_pct, ${studyCase}), 2) AS benchmark_ctr_pct,
+        IF(curve.measured_ctr_pct IS NULL, 'study', 'measured') AS benchmark_source,
+        curve.rank_impressions AS benchmark_rank_impressions`
+      : `ROUND(${studyCase}, 2) AS benchmark_ctr_pct,
+        'study' AS benchmark_source,
+        CAST(NULL AS INT64) AS benchmark_rank_impressions`;
+
+  const benchmarkJoin =
+    benchmark === "measured"
+      ? `LEFT JOIN curve
+        ON CAST(ROUND(page_metrics.avg_position) AS INT64) = curve.rank`
+      : "";
 
   const sql = `
     WITH page_metrics AS (
@@ -25,22 +85,12 @@ export async function gscCtrBenchmark(
       GROUP BY url
       HAVING impressions >= ${minImpressions} AND avg_position <= 20
     ),
-    with_benchmark AS (
-      SELECT *,
-        CASE
-          WHEN avg_position <= 1 THEN 28.5
-          WHEN avg_position <= 2 THEN 15.7
-          WHEN avg_position <= 3 THEN 11.0
-          WHEN avg_position <= 4 THEN 8.0
-          WHEN avg_position <= 5 THEN 7.2
-          WHEN avg_position <= 6 THEN 5.1
-          WHEN avg_position <= 7 THEN 4.0
-          WHEN avg_position <= 8 THEN 3.2
-          WHEN avg_position <= 9 THEN 2.8
-          WHEN avg_position <= 10 THEN 2.5
-          ELSE GREATEST(0.5, 2.5 - (avg_position - 10) * 0.2)
-        END AS benchmark_ctr_pct
+    ${benchmarkCTE}with_benchmark AS (
+      SELECT
+        page_metrics.*,
+        ${benchmarkSelect}
       FROM page_metrics
+      ${benchmarkJoin}
     )
     SELECT
       url,
@@ -49,6 +99,8 @@ export async function gscCtrBenchmark(
       actual_ctr_pct,
       avg_position,
       benchmark_ctr_pct,
+      benchmark_source,
+      benchmark_rank_impressions,
       ROUND(actual_ctr_pct - benchmark_ctr_pct, 2) AS gap_pct,
       CASE
         WHEN actual_ctr_pct - benchmark_ctr_pct >= 2.0 THEN 'Above benchmark'

--- a/src/tools/gsc-discover.ts
+++ b/src/tools/gsc-discover.ts
@@ -1,0 +1,156 @@
+import { runQuery } from "./query.js";
+import { getConfig, validateIdentifier } from "../client.js";
+import {
+  GRANULARITY_TRUNC,
+  Granularity,
+  escapeSQLString,
+  getLastExportDate,
+} from "./gsc-shared.js";
+
+type QueryResult = { rows: Record<string, unknown>[]; totalRows: number; bytesProcessed: string };
+
+/**
+ * Google Discover performance from the bulk export.
+ *
+ * Discover is page-based: there is no query dimension, so nothing here groups
+ * by query. Its own anonymisation flag is `is_anonymized_discover`, separate
+ * from `is_anonymized_query`.
+ *
+ * There is deliberately no device breakdown: `device` is NULL on every Discover
+ * row, so the block only ever returned a single empty bucket holding every
+ * click. Mobile versus desktop is not answerable for this surface.
+ */
+export async function gscDiscover(
+  days: number = 28,
+  granularity: Granularity = "week",
+  urlContains?: string,
+  topUrls: number = 50,
+  dataset?: string
+): Promise<{
+  period: { startDate: string; endDate: string; days: number; anchoredTo: string };
+  summary: QueryResult;
+  shareOfSite: QueryResult;
+  timeSeries: QueryResult | null;
+  topUrls: QueryResult;
+  byCountry: QueryResult;
+}> {
+  const config = getConfig();
+  const ds = dataset || config.defaultDataset || "searchconsole";
+  validateIdentifier(ds, "dataset");
+
+  const lastDay = await getLastExportDate(ds, runQuery);
+  const table = `\`${ds}.searchdata_url_impression\``;
+
+  const window = `data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days} DAY)
+      AND data_date <= DATE '${lastDay}'`;
+  const urlScope = urlContains ? `AND url LIKE '%${escapeSQLString(urlContains)}%'` : "";
+
+  const summarySQL = `
+    SELECT
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      COUNT(DISTINCT url) AS urls,
+      SUM(IF(is_anonymized_discover, clicks, 0)) AS anonymized_clicks,
+      ROUND(SAFE_DIVIDE(SUM(IF(is_anonymized_discover, clicks, 0)), SUM(clicks)) * 100, 2)
+        AS anonymized_clicks_share_pct
+    FROM ${table}
+    WHERE ${window}
+      AND search_type = 'DISCOVER'
+      ${urlScope}
+    LIMIT 1
+  `;
+
+  // Discover next to the other surfaces, so its weight is visible rather than
+  // stated in isolation.
+  const shareOfSiteSQL = `
+    SELECT
+      search_type,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(SUM(clicks)) OVER ()) * 100, 2) AS click_share_pct
+    FROM ${table}
+    WHERE ${window}
+      ${urlScope}
+    GROUP BY search_type
+    ORDER BY clicks DESC
+    LIMIT 10
+  `;
+
+  let timeSeriesSQL: string | null = null;
+  if (granularity !== "none") {
+    timeSeriesSQL = `
+      SELECT
+        DATE_TRUNC(data_date, ${GRANULARITY_TRUNC[granularity]}) AS bucket,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+        COUNT(DISTINCT url) AS urls
+      FROM ${table}
+      WHERE ${window}
+        AND search_type = 'DISCOVER'
+        ${urlScope}
+      GROUP BY bucket
+      ORDER BY bucket
+      LIMIT 400
+    `;
+  }
+
+  const topUrlsSQL = `
+    SELECT
+      url,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      MIN(data_date) AS first_day,
+      MAX(data_date) AS last_day
+    FROM ${table}
+    WHERE ${window}
+      AND search_type = 'DISCOVER'
+      ${urlScope}
+    GROUP BY url
+    ORDER BY clicks DESC
+    LIMIT ${Math.min(topUrls, 500)}
+  `;
+
+  const byCountrySQL = `
+    SELECT
+      country,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct
+    FROM ${table}
+    WHERE ${window}
+      AND search_type = 'DISCOVER'
+      ${urlScope}
+    GROUP BY country
+    ORDER BY clicks DESC
+    LIMIT 20
+  `;
+
+  const [summary, shareOfSite, timeSeries, topUrlsResult, byCountry] = await Promise.all([
+    runQuery(summarySQL, 1),
+    runQuery(shareOfSiteSQL, 10),
+    timeSeriesSQL ? runQuery(timeSeriesSQL, 400) : Promise.resolve(null),
+    runQuery(topUrlsSQL, Math.min(topUrls, 500)),
+    runQuery(byCountrySQL, 20),
+  ]);
+
+  const start = new Date(lastDay);
+  start.setUTCDate(start.getUTCDate() - days + 1);
+
+  return {
+    period: {
+      startDate: start.toISOString().split("T")[0],
+      endDate: lastDay,
+      days,
+      anchoredTo: `latest day in the export (${lastDay}), not today`,
+    },
+    summary,
+    shareOfSite,
+    timeSeries,
+    topUrls: topUrlsResult,
+    byCountry,
+  };
+}

--- a/src/tools/gsc-image-search.ts
+++ b/src/tools/gsc-image-search.ts
@@ -1,0 +1,210 @@
+import { runQuery } from "./query.js";
+import { getConfig, validateIdentifier } from "../client.js";
+import {
+  AVG_POSITION_SQL,
+  GRANULARITY_TRUNC,
+  Granularity,
+  escapeSQLString,
+  getLastExportDate,
+} from "./gsc-shared.js";
+
+type QueryResult = { rows: Record<string, unknown>[]; totalRows: number; bytesProcessed: string };
+
+/**
+ * Google Images performance from the bulk export.
+ *
+ * Unlike Discover, image search does carry queries, so this groups by both url
+ * and query. The url is the page the image sits on, never the image file - the
+ * export has no image-level dimension, which is the honest limit of this
+ * surface and the reason a low image CTR says little about the image itself.
+ *
+ * `is_amp_image_result` is reported alongside, because an AMP image result is a
+ * different SERP element from an ordinary image result.
+ */
+export async function gscImageSearch(
+  days: number = 28,
+  granularity: Granularity = "week",
+  urlContains?: string,
+  topRows: number = 50,
+  dataset?: string
+): Promise<{
+  period: { startDate: string; endDate: string; days: number; anchoredTo: string };
+  summary: QueryResult;
+  shareOfSite: QueryResult;
+  timeSeries: QueryResult | null;
+  topUrls: QueryResult;
+  topQueries: QueryResult;
+  byDevice: QueryResult;
+  byCountry: QueryResult;
+  note: string;
+}> {
+  const config = getConfig();
+  const ds = dataset || config.defaultDataset || "searchconsole";
+  validateIdentifier(ds, "dataset");
+
+  const lastDay = await getLastExportDate(ds, runQuery);
+  const table = `\`${ds}.searchdata_url_impression\``;
+
+  const window = `data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days} DAY)
+      AND data_date <= DATE '${lastDay}'`;
+  const urlScope = urlContains ? `AND url LIKE '%${escapeSQLString(urlContains)}%'` : "";
+  const imageScope = `AND search_type = 'IMAGE'`;
+  const limit = Math.min(topRows, 500);
+
+  const summarySQL = `
+    SELECT
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+      COUNT(DISTINCT url) AS urls,
+      COUNT(DISTINCT query) AS visible_queries,
+      SUM(IF(is_anonymized_query, clicks, 0)) AS anonymized_clicks,
+      ROUND(SAFE_DIVIDE(SUM(IF(is_anonymized_query, clicks, 0)), SUM(clicks)) * 100, 2)
+        AS anonymized_clicks_share_pct,
+      SUM(IF(is_amp_image_result, clicks, 0)) AS amp_image_result_clicks,
+      SUM(IF(is_amp_image_result, impressions, 0)) AS amp_image_result_impressions
+    FROM ${table}
+    WHERE ${window}
+      ${imageScope}
+      ${urlScope}
+    LIMIT 1
+  `;
+
+  const shareOfSiteSQL = `
+    SELECT
+      search_type,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(SUM(clicks)) OVER ()) * 100, 2) AS click_share_pct
+    FROM ${table}
+    WHERE ${window}
+      ${urlScope}
+    GROUP BY search_type
+    ORDER BY clicks DESC
+    LIMIT 10
+  `;
+
+  let timeSeriesSQL: string | null = null;
+  if (granularity !== "none") {
+    timeSeriesSQL = `
+      SELECT
+        DATE_TRUNC(data_date, ${GRANULARITY_TRUNC[granularity]}) AS bucket,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+        ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+        COUNT(DISTINCT url) AS urls
+      FROM ${table}
+      WHERE ${window}
+        ${imageScope}
+        ${urlScope}
+      GROUP BY bucket
+      ORDER BY bucket
+      LIMIT 400
+    `;
+  }
+
+  const topUrlsSQL = `
+    SELECT
+      url,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+      COUNT(DISTINCT query) AS queries
+    FROM ${table}
+    WHERE ${window}
+      ${imageScope}
+      ${urlScope}
+    GROUP BY url
+    ORDER BY impressions DESC
+    LIMIT ${limit}
+  `;
+
+  const topQueriesSQL = `
+    SELECT
+      query,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+      COUNT(DISTINCT url) AS urls
+    FROM ${table}
+    WHERE ${window}
+      ${imageScope}
+      AND query IS NOT NULL
+      ${urlScope}
+    GROUP BY query
+    ORDER BY impressions DESC
+    LIMIT ${limit}
+  `;
+
+  const byDeviceSQL = `
+    SELECT
+      device,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+      ROUND(${AVG_POSITION_SQL}, 1) AS avg_position
+    FROM ${table}
+    WHERE ${window}
+      ${imageScope}
+      ${urlScope}
+    GROUP BY device
+    ORDER BY clicks DESC
+    LIMIT 10
+  `;
+
+  const byCountrySQL = `
+    SELECT
+      country,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct
+    FROM ${table}
+    WHERE ${window}
+      ${imageScope}
+      ${urlScope}
+    GROUP BY country
+    ORDER BY clicks DESC
+    LIMIT 20
+  `;
+
+  const [summary, shareOfSite, timeSeries, topUrls, topQueries, byDevice, byCountry] =
+    await Promise.all([
+      runQuery(summarySQL, 1),
+      runQuery(shareOfSiteSQL, 10),
+      timeSeriesSQL ? runQuery(timeSeriesSQL, 400) : Promise.resolve(null),
+      runQuery(topUrlsSQL, limit),
+      runQuery(topQueriesSQL, limit),
+      runQuery(byDeviceSQL, 10),
+      runQuery(byCountrySQL, 20),
+    ]);
+
+  const start = new Date(lastDay);
+  start.setUTCDate(start.getUTCDate() - days + 1);
+
+  const impressions = Number(summary.rows[0]?.impressions ?? 0);
+
+  return {
+    period: {
+      startDate: start.toISOString().split("T")[0],
+      endDate: lastDay,
+      days,
+      anchoredTo: `latest day in the export (${lastDay}), not today`,
+    },
+    summary,
+    shareOfSite,
+    timeSeries,
+    topUrls,
+    topQueries,
+    byDevice,
+    byCountry,
+    note:
+      impressions > 0
+        ? "url is the page hosting the image, not the image file: the export carries no image-level dimension. A weak CTR here therefore points at the page and its thumbnail in the grid, not necessarily at the image itself."
+        : "No image search impressions in this window. Either the property is not indexed in Google Images, or images are served from a different property than this one.",
+  };
+}

--- a/src/tools/gsc-query-count.ts
+++ b/src/tools/gsc-query-count.ts
@@ -1,0 +1,239 @@
+import { runQuery } from "./query.js";
+import { getConfig, validateIdentifier } from "../client.js";
+import {
+  AVG_POSITION_SQL,
+  positionGroupSQL,
+  GRANULARITY_TRUNC,
+  Granularity,
+  normaliseSearchType,
+  escapeSQLString,
+  getLastExportDate,
+  deviceCountryConditions,
+} from "./gsc-shared.js";
+
+type QueryResult = { rows: Record<string, unknown>[]; totalRows: number; bytesProcessed: string };
+
+/**
+ * Query counting on the warehouse instead of the API.
+ *
+ * Two things this can do that the API version cannot: it counts across the full
+ * export instead of a 1,000-row page, and it reads the anonymized share from
+ * the `is_anonymized_query` flag rather than inferring it from a click gap.
+ */
+export async function gscQueryCount(
+  days: number = 28,
+  url?: string,
+  urlContains?: string,
+  granularity: Granularity = "none",
+  minPosition?: number,
+  maxPosition?: number,
+  searchType: string = "WEB",
+  topPages?: number,
+  device?: string,
+  country?: string,
+  dataset?: string
+): Promise<{
+  period: { startDate: string; endDate: string; days: number; anchoredTo: string };
+  totals: QueryResult;
+  byPositionGroup: QueryResult;
+  periodComparison: QueryResult;
+  timeSeries: QueryResult | null;
+  topPagesByQueryCount: QueryResult | null;
+}> {
+  const config = getConfig();
+  const ds = dataset || config.defaultDataset || "searchconsole";
+  validateIdentifier(ds, "dataset");
+  const type = normaliseSearchType(searchType);
+
+  if (type === "DISCOVER") {
+    throw new Error(
+      "Discover carries no query dimension, so there is nothing to count. Use gsc_discover instead."
+    );
+  }
+
+  const lastDay = await getLastExportDate(ds, runQuery);
+  const table = `\`${ds}.searchdata_url_impression\``;
+
+  const scope: string[] = [`search_type = '${type}'`];
+  if (url) scope.push(`url = '${escapeSQLString(url)}'`);
+  if (urlContains) scope.push(`url LIKE '%${escapeSQLString(urlContains)}%'`);
+  scope.push(...deviceCountryConditions(device, country, type));
+  const scopeSQL = scope.length ? `AND ${scope.join("\n      AND ")}` : "";
+
+  const currentWindow = `data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days} DAY)
+      AND data_date <= DATE '${lastDay}'`;
+
+  const positionFilter: string[] = [];
+  if (minPosition !== undefined) positionFilter.push(`position >= ${minPosition}`);
+  if (maxPosition !== undefined) positionFilter.push(`position <= ${maxPosition}`);
+  const positionFilterSQL = positionFilter.length ? `WHERE ${positionFilter.join(" AND ")}` : "";
+
+  // The anonymized gap is deliberately NOT position-filtered: anonymized rows
+  // carry no query and therefore no position, so filtering would just hide them.
+  const totalsSQL = `
+    SELECT
+      COUNT(DISTINCT query) AS visible_queries,
+      SUM(IF(is_anonymized_query, 0, clicks)) AS clicks_from_visible_queries,
+      SUM(clicks) AS total_clicks,
+      SUM(IF(is_anonymized_query, clicks, 0)) AS anonymized_clicks,
+      ROUND(SAFE_DIVIDE(SUM(IF(is_anonymized_query, clicks, 0)), SUM(clicks)) * 100, 2)
+        AS anonymized_clicks_share_pct,
+      SUM(impressions) AS total_impressions
+    FROM ${table}
+    WHERE ${currentWindow}
+      ${scopeSQL}
+    LIMIT 1
+  `;
+
+  const byPositionGroupSQL = `
+    WITH per_query AS (
+      SELECT
+        query,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ${AVG_POSITION_SQL} AS position
+      FROM ${table}
+      WHERE ${currentWindow}
+        AND query IS NOT NULL
+        ${scopeSQL}
+      GROUP BY query
+    )
+    SELECT
+      ${positionGroupSQL("position")} AS position_group,
+      COUNT(*) AS queries,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions,
+      ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct
+    FROM per_query
+    ${positionFilterSQL}
+    GROUP BY position_group
+    ORDER BY MIN(position)
+    LIMIT 10
+  `;
+
+  const periodComparisonSQL = `
+    WITH tagged AS (
+      SELECT
+        query,
+        clicks,
+        impressions,
+        sum_position,
+        IF(
+          data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days} DAY),
+          'current',
+          'previous'
+        ) AS period
+      FROM ${table}
+      WHERE data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days * 2} DAY)
+        AND data_date <= DATE '${lastDay}'
+        AND query IS NOT NULL
+        ${scopeSQL}
+    ),
+    per_period_query AS (
+      SELECT
+        period,
+        query,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ${AVG_POSITION_SQL} AS position
+      FROM tagged
+      GROUP BY period, query
+    )
+    SELECT
+      period,
+      COUNT(*) AS visible_queries,
+      SUM(clicks) AS clicks,
+      SUM(impressions) AS impressions
+    FROM per_period_query
+    ${positionFilterSQL}
+    GROUP BY period
+    ORDER BY period DESC
+    LIMIT 2
+  `;
+
+  let timeSeriesSQL: string | null = null;
+  if (granularity !== "none") {
+    const trunc = GRANULARITY_TRUNC[granularity];
+    timeSeriesSQL = `
+      WITH per_bucket_query AS (
+        SELECT
+          DATE_TRUNC(data_date, ${trunc}) AS bucket,
+          query,
+          SUM(clicks) AS clicks,
+          SUM(impressions) AS impressions,
+          ${AVG_POSITION_SQL} AS position
+        FROM ${table}
+        WHERE ${currentWindow}
+          AND query IS NOT NULL
+          ${scopeSQL}
+        GROUP BY bucket, query
+      )
+      SELECT
+        bucket,
+        COUNT(*) AS visible_queries,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct
+      FROM per_bucket_query
+      ${positionFilterSQL}
+      GROUP BY bucket
+      ORDER BY bucket
+      LIMIT 400
+    `;
+  }
+
+  let topPagesSQL: string | null = null;
+  if (topPages && topPages > 0) {
+    topPagesSQL = `
+      WITH per_page_query AS (
+        SELECT
+          url,
+          query,
+          SUM(clicks) AS clicks,
+          SUM(impressions) AS impressions,
+          ${AVG_POSITION_SQL} AS position
+        FROM ${table}
+        WHERE ${currentWindow}
+          AND query IS NOT NULL
+          ${scopeSQL}
+        GROUP BY url, query
+      )
+      SELECT
+        url,
+        COUNT(*) AS queries,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ROUND(AVG(position), 1) AS avg_position
+      FROM per_page_query
+      ${positionFilterSQL}
+      GROUP BY url
+      ORDER BY queries DESC
+      LIMIT ${Math.min(topPages, 500)}
+    `;
+  }
+
+  const [totals, byPositionGroup, periodComparison, timeSeries, topPagesResult] = await Promise.all([
+    runQuery(totalsSQL, 1),
+    runQuery(byPositionGroupSQL, 10),
+    runQuery(periodComparisonSQL, 2),
+    timeSeriesSQL ? runQuery(timeSeriesSQL, 400) : Promise.resolve(null),
+    topPagesSQL ? runQuery(topPagesSQL, Math.min(topPages || 0, 500)) : Promise.resolve(null),
+  ]);
+
+  const startDateSQL = new Date(lastDay);
+  startDateSQL.setUTCDate(startDateSQL.getUTCDate() - days + 1);
+
+  return {
+    period: {
+      startDate: startDateSQL.toISOString().split("T")[0],
+      endDate: lastDay,
+      days,
+      anchoredTo: `latest day in the export (${lastDay}), not today`,
+    },
+    totals,
+    byPositionGroup,
+    periodComparison,
+    timeSeries,
+    topPagesByQueryCount: topPagesResult,
+  };
+}

--- a/src/tools/gsc-shared.ts
+++ b/src/tools/gsc-shared.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared SQL building blocks for the GSC bulk export tables.
+ */
+
+/**
+ * Average position from the GSC bulk export.
+ *
+ * `sum_position` is ZERO-BASED, so the average rank is sum/impressions + 1.
+ * Verified against a live export: over one week, 12,544 of 411,617 (url, query)
+ * pairs have sum_position/impressions below 1 and the minimum is exactly 0 -
+ * and position 0 does not exist in Google Search.
+ *
+ * This matches the `+ 1` the rest of the server applies since v4.1.1.
+ */
+export const AVG_POSITION_SQL = "SAFE_DIVIDE(SUM(sum_position), SUM(impressions)) + 1";
+
+/** Position group buckets, matching query_count in the GSC API MCP server. */
+export function positionGroupSQL(column: string): string {
+  return `CASE
+        WHEN ${column} <= 3 THEN '1-3'
+        WHEN ${column} <= 10 THEN '4-10'
+        WHEN ${column} <= 20 THEN '11-20'
+        WHEN ${column} <= 50 THEN '21-50'
+        ELSE '51+'
+      END`;
+}
+
+export type Granularity = "none" | "day" | "week" | "month";
+
+export const GRANULARITY_TRUNC: Record<Exclude<Granularity, "none">, string> = {
+  day: "DAY",
+  week: "WEEK(MONDAY)",
+  month: "MONTH",
+};
+
+/** Search types as spelled in the export (uppercase, unlike the API). */
+export const SEARCH_TYPES = ["WEB", "IMAGE", "VIDEO", "NEWS", "GOOGLE_NEWS", "DISCOVER"] as const;
+export type ExportSearchType = (typeof SEARCH_TYPES)[number];
+
+export function normaliseSearchType(value: string): ExportSearchType {
+  const upper = value.toUpperCase().replace(/-/g, "_") as ExportSearchType;
+  if (!SEARCH_TYPES.includes(upper)) {
+    throw new Error(
+      `Unknown search_type "${value}". Allowed: ${SEARCH_TYPES.join(", ")}.`
+    );
+  }
+  return upper;
+}
+
+/** Devices as spelled in the export. */
+export const DEVICES = ["MOBILE", "DESKTOP", "TABLET"] as const;
+export type Device = (typeof DEVICES)[number];
+
+export function normaliseDevice(value: string): Device {
+  const upper = value.toUpperCase() as Device;
+  if (!DEVICES.includes(upper)) {
+    throw new Error(`Unknown device "${value}". Allowed: ${DEVICES.join(", ")}.`);
+  }
+  return upper;
+}
+
+/** Countries are ISO-3166-1 alpha-3, lowercase in the export (deu, aut, che, usa). */
+export function normaliseCountry(value: string): string {
+  const lower = value.toLowerCase();
+  if (!/^[a-z]{3}$/.test(lower)) {
+    throw new Error(
+      `Country must be an ISO-3166-1 alpha-3 code such as deu, aut, che or usa - got "${value}".`
+    );
+  }
+  return lower;
+}
+
+/**
+ * WHERE conditions for device and country.
+ *
+ * Both are optional and unset means unfiltered - every tool keeps returning all
+ * devices and all countries unless asked otherwise.
+ *
+ * Discover carries no device: the column is NULL on every DISCOVER row, so a
+ * device filter there would silently return nothing. That fails loudly instead.
+ */
+export function deviceCountryConditions(
+  device?: string,
+  country?: string,
+  searchType?: string
+): string[] {
+  const conditions: string[] = [];
+
+  if (device) {
+    if (searchType && searchType.toUpperCase() === "DISCOVER") {
+      throw new Error(
+        "Discover rows carry no device - the column is NULL for every Discover impression, so a device filter cannot match. Drop the device argument, or query a different surface."
+      );
+    }
+    conditions.push(`device = '${normaliseDevice(device)}'`);
+  }
+
+  if (country) {
+    conditions.push(`country = '${normaliseCountry(country)}'`);
+  }
+
+  return conditions;
+}
+
+/** Doubles single quotes, matching the escaping the other tools in this server use. */
+export function escapeSQLString(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/**
+ * Latest day present in the export.
+ *
+ * Anchoring ranges here instead of CURRENT_DATE() matters: the bulk export
+ * trails by two to three days, so a CURRENT_DATE()-based window silently
+ * includes empty days and drags period comparisons down with it. Same principle
+ * as the inline `(SELECT MAX(data_date) ...)` subqueries v4.1.1 introduced,
+ * resolved once per call so these tools can also label the window they used.
+ */
+export async function getLastExportDate(
+  ds: string,
+  runQuery: (sql: string, maxRows?: number) => Promise<{ rows: Record<string, unknown>[] }>
+): Promise<string> {
+  const result = await runQuery(
+    `SELECT MAX(data_date) AS last_day FROM \`${ds}.searchdata_url_impression\` LIMIT 1`,
+    1
+  );
+  const raw = result.rows[0]?.last_day as { value?: string } | string | undefined;
+  const value = typeof raw === "object" && raw !== null ? raw.value : raw;
+  if (!value) {
+    throw new Error(
+      `No data found in \`${ds}.searchdata_url_impression\`. Is the GSC bulk export set up for this dataset?`
+    );
+  }
+  return value;
+}

--- a/src/tools/gsc-shared.ts
+++ b/src/tools/gsc-shared.ts
@@ -108,6 +108,77 @@ export function escapeSQLString(value: string): string {
 }
 
 /**
+ * The published study curve as a SQL CASE - the fallback, not the default.
+ *
+ * These are somebody else's averages, taken across unrelated sites. Measured
+ * against one content property, the real CTR at position 1 was 3.54% against
+ * the 28.5% here: a factor of eight. Benchmarking a site against these numbers
+ * marks almost every page as underperforming, which is why this is only used
+ * for ranks where the property's own data is too thin to measure.
+ */
+export function studyBenchmarkCaseSQL(positionColumn: string): string {
+  return `CASE
+          WHEN ${positionColumn} <= 1 THEN 28.5
+          WHEN ${positionColumn} <= 2 THEN 15.7
+          WHEN ${positionColumn} <= 3 THEN 11.0
+          WHEN ${positionColumn} <= 4 THEN 8.0
+          WHEN ${positionColumn} <= 5 THEN 7.2
+          WHEN ${positionColumn} <= 6 THEN 5.1
+          WHEN ${positionColumn} <= 7 THEN 4.0
+          WHEN ${positionColumn} <= 8 THEN 3.2
+          WHEN ${positionColumn} <= 9 THEN 2.8
+          WHEN ${positionColumn} <= 10 THEN 2.5
+          ELSE GREATEST(0.5, 2.5 - (${positionColumn} - 10) * 0.2)
+        END`;
+}
+
+/**
+ * CTEs that build the property's own click curve from the export:
+ * `curve_pairs` and `curve`.
+ *
+ * Aggregate to (url, query) first and take that pair's average position, then
+ * bundle by rounded rank. CTR per rank is summed clicks over summed
+ * impressions, never a mean of ratios, so high-volume pairs carry the weight
+ * they should. Ranks below minImpressionsPerRank are dropped rather than
+ * reported as noise; callers are expected to fall back to studyBenchmarkCaseSQL
+ * for those.
+ *
+ * The window is separate from the caller's analysis window on purpose: a curve
+ * needs volume per rank, so it reads further back than the period being judged.
+ * It is also the cost lever - this CTE scans curveDays of
+ * searchdata_url_impression.
+ */
+export function measuredCurveCTEs(
+  ds: string,
+  curveDays: number = 90,
+  minImpressionsPerRank: number = 100,
+  scopeSQL: string = ""
+): string {
+  return `curve_pairs AS (
+      SELECT
+        SUM(clicks) AS curve_clicks,
+        SUM(impressions) AS curve_impressions,
+        ${AVG_POSITION_SQL} AS curve_position
+      FROM \`${ds}.searchdata_url_impression\`
+      WHERE
+        data_date >= DATE_SUB((SELECT MAX(data_date) FROM \`${ds}.searchdata_url_impression\`), INTERVAL ${curveDays} DAY)
+        AND search_type = 'WEB'
+        AND query IS NOT NULL
+        ${scopeSQL}
+      GROUP BY url, query
+    ),
+    curve AS (
+      SELECT
+        CAST(ROUND(curve_position) AS INT64) AS rank,
+        SAFE_DIVIDE(SUM(curve_clicks), SUM(curve_impressions)) * 100 AS measured_ctr_pct,
+        SUM(curve_impressions) AS rank_impressions
+      FROM curve_pairs
+      GROUP BY rank
+      HAVING SUM(curve_impressions) >= ${minImpressionsPerRank}
+    )`;
+}
+
+/**
  * Latest day present in the export.
  *
  * Anchoring ranges here instead of CURRENT_DATE() matters: the bulk export

--- a/src/tools/gsc-shopping.ts
+++ b/src/tools/gsc-shopping.ts
@@ -1,0 +1,207 @@
+import { runQuery } from "./query.js";
+import { getConfig, validateIdentifier } from "../client.js";
+import {
+  AVG_POSITION_SQL,
+  GRANULARITY_TRUNC,
+  Granularity,
+  escapeSQLString,
+  getLastExportDate,
+} from "./gsc-shared.js";
+
+type QueryResult = { rows: Record<string, unknown>[]; totalRows: number; bytesProcessed: string };
+
+/**
+ * Organic shopping surfaces: free product listings, merchant listings and
+ * product snippets.
+ *
+ * These are search appearances, not search types - they live inside WEB rows,
+ * flagged by their own boolean columns. The GSC API exposes them only through
+ * the searchAppearance dimension, which cannot be combined with other
+ * groupings; here they are ordinary columns, so they can be crossed with url,
+ * query, device and date freely.
+ *
+ * A property that sells nothing returns zeros. That is an answer, not a bug,
+ * and the result says so explicitly instead of looking like a failed query.
+ */
+export const SHOPPING_APPEARANCES = {
+  organic_shopping: "is_organic_shopping",
+  merchant_listings: "is_merchant_listings",
+  product_snippets: "is_product_snippets",
+} as const;
+
+export type ShoppingAppearance = keyof typeof SHOPPING_APPEARANCES;
+
+export async function gscShopping(
+  days: number = 28,
+  appearance?: ShoppingAppearance,
+  granularity: Granularity = "week",
+  urlContains?: string,
+  topRows: number = 50,
+  dataset?: string
+): Promise<{
+  period: { startDate: string; endDate: string; days: number; anchoredTo: string };
+  overview: QueryResult;
+  dataAvailable: boolean;
+  note: string;
+  drilldown: {
+    appearance: ShoppingAppearance;
+    topUrls: QueryResult;
+    topQueries: QueryResult;
+    timeSeries: QueryResult | null;
+  } | null;
+}> {
+  const config = getConfig();
+  const ds = dataset || config.defaultDataset || "searchconsole";
+  validateIdentifier(ds, "dataset");
+
+  if (appearance && !(appearance in SHOPPING_APPEARANCES)) {
+    throw new Error(
+      `Unknown appearance "${appearance}". Allowed: ${Object.keys(SHOPPING_APPEARANCES).join(", ")}.`
+    );
+  }
+
+  const lastDay = await getLastExportDate(ds, runQuery);
+  const table = `\`${ds}.searchdata_url_impression\``;
+
+  const window = `data_date > DATE_SUB(DATE '${lastDay}', INTERVAL ${days} DAY)
+      AND data_date <= DATE '${lastDay}'`;
+  const urlScope = urlContains ? `AND url LIKE '%${escapeSQLString(urlContains)}%'` : "";
+
+  const metricsFor = (name: string, column: string) => `
+      SUM(IF(${column}, clicks, 0)) AS ${name}_clicks,
+      SUM(IF(${column}, impressions, 0)) AS ${name}_impressions,
+      ROUND(SAFE_DIVIDE(
+        SUM(IF(${column}, clicks, 0)), SUM(IF(${column}, impressions, 0))
+      ) * 100, 2) AS ${name}_ctr_pct,
+      ROUND(SAFE_DIVIDE(
+        SUM(IF(${column}, sum_position, 0)), SUM(IF(${column}, impressions, 0))
+      ) + 1, 1) AS ${name}_avg_position,
+      COUNT(DISTINCT IF(${column}, url, NULL)) AS ${name}_urls,
+      COUNT(DISTINCT IF(${column}, query, NULL)) AS ${name}_queries`;
+
+  const overviewSQL = `
+    SELECT
+      ${metricsFor("organic_shopping", "is_organic_shopping")},
+      ${metricsFor("merchant_listings", "is_merchant_listings")},
+      ${metricsFor("product_snippets", "is_product_snippets")},
+      SUM(clicks) AS all_clicks,
+      SUM(impressions) AS all_impressions
+    FROM ${table}
+    WHERE ${window}
+      ${urlScope}
+    LIMIT 1
+  `;
+
+  const overview = await runQuery(overviewSQL, 1);
+  const row = overview.rows[0] || {};
+  const clicksOf = (name: string) => Number(row[`${name}_clicks`] ?? 0);
+  const impressionsOf = (name: string) => Number(row[`${name}_impressions`] ?? 0);
+  const totalShoppingImpressions =
+    impressionsOf("organic_shopping") +
+    impressionsOf("merchant_listings") +
+    impressionsOf("product_snippets");
+
+  const dataAvailable = totalShoppingImpressions > 0;
+  const present = (Object.keys(SHOPPING_APPEARANCES) as ShoppingAppearance[]).filter(
+    (name) => impressionsOf(name) > 0
+  );
+  const absent = (Object.keys(SHOPPING_APPEARANCES) as ShoppingAppearance[]).filter(
+    (name) => impressionsOf(name) === 0
+  );
+  const note = dataAvailable
+    ? `Present with impressions: ${present
+        .map((name) => `${name} (${clicksOf(name)} clicks)`)
+        .join(", ")}.` +
+      (absent.length
+        ? ` No impressions at all on: ${absent.join(", ")} - the property does not appear on ${
+            absent.length === 1 ? "that surface" : "those surfaces"
+          }. Do not read a figure from one appearance as evidence for another.`
+        : "")
+    : "No impressions on any organic shopping surface in this window. The property appears in neither free product listings, merchant listings nor product snippets - typical for a site that sells nothing. Report this as a finding, not as missing data.";
+
+  let drilldown: Awaited<ReturnType<typeof gscShopping>>["drilldown"] = null;
+  if (appearance) {
+    const column = SHOPPING_APPEARANCES[appearance];
+    const flagScope = `AND ${column}`;
+    const limit = Math.min(topRows, 500);
+
+    const topUrlsSQL = `
+      SELECT
+        url,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+        ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+        COUNT(DISTINCT query) AS queries
+      FROM ${table}
+      WHERE ${window}
+        ${flagScope}
+        ${urlScope}
+      GROUP BY url
+      ORDER BY clicks DESC
+      LIMIT ${limit}
+    `;
+
+    const topQueriesSQL = `
+      SELECT
+        query,
+        SUM(clicks) AS clicks,
+        SUM(impressions) AS impressions,
+        ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+        ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+        COUNT(DISTINCT url) AS urls
+      FROM ${table}
+      WHERE ${window}
+        ${flagScope}
+        AND query IS NOT NULL
+        ${urlScope}
+      GROUP BY query
+      ORDER BY clicks DESC
+      LIMIT ${limit}
+    `;
+
+    let timeSeriesSQL: string | null = null;
+    if (granularity !== "none") {
+      timeSeriesSQL = `
+        SELECT
+          DATE_TRUNC(data_date, ${GRANULARITY_TRUNC[granularity]}) AS bucket,
+          SUM(clicks) AS clicks,
+          SUM(impressions) AS impressions,
+          ROUND(SAFE_DIVIDE(SUM(clicks), SUM(impressions)) * 100, 2) AS ctr_pct,
+          ROUND(${AVG_POSITION_SQL}, 1) AS avg_position,
+          COUNT(DISTINCT url) AS urls
+        FROM ${table}
+        WHERE ${window}
+          ${flagScope}
+          ${urlScope}
+        GROUP BY bucket
+        ORDER BY bucket
+        LIMIT 400
+      `;
+    }
+
+    const [topUrls, topQueries, timeSeries] = await Promise.all([
+      runQuery(topUrlsSQL, limit),
+      runQuery(topQueriesSQL, limit),
+      timeSeriesSQL ? runQuery(timeSeriesSQL, 400) : Promise.resolve(null),
+    ]);
+
+    drilldown = { appearance, topUrls, topQueries, timeSeries };
+  }
+
+  const start = new Date(lastDay);
+  start.setUTCDate(start.getUTCDate() - days + 1);
+
+  return {
+    period: {
+      startDate: start.toISOString().split("T")[0],
+      endDate: lastDay,
+      days,
+      anchoredTo: `latest day in the export (${lastDay}), not today`,
+    },
+    overview,
+    dataAvailable,
+    note,
+    drilldown,
+  };
+}


### PR DESCRIPTION
**Draft on purpose — please don't merge this yet.** It is stacked on #2, so merging it before #2 would pull those five tools in through the back door. Opening it now only so the measurement below has somewhere to live while you look at #2.

**Read this commit, not the diff.** GitHub shows #2's five commits here as well. The only new work is one commit: [`e8de3b3`](https://github.com/david-wulf/BigQuery-MCP-Server/commit/e8de3b3bd687749a931ce1ec761b4f49197d1813) — 146 lines across 4 files. Once #2 lands I'll rebase onto `main` and this becomes a clean single-commit PR against it.

### What it does

`gsc_ctr_benchmark`'s benchmark table is a published study across unrelated sites: it assumes position 1 draws 28.5%. The benchmark now defaults to the property's own click curve built from the export, with the study table kept as the fallback for ranks the property has too little data to measure.

### Measured, not argued

Same 8,270 qualifying pages, same verdict thresholds, same 28-day window on the same property. Only the reference curve changes:

| verdict | study table | measured curve |
|---|---:|---:|
| Significantly below benchmark | 1,040 | **0** |
| Below benchmark | 4,241 | **94** |
| At benchmark | 2,860 | **7,574** |
| Above benchmark | 129 | **602** |

The study table calls **64% of the property underperforming**. The measured curve calls 1.1%. Position 1 on this property draws 3.73% against the table's assumed 28.5%.

**Cost barely moves:** 4.14 GB against 3.52 GB, +18%. I expected roughly triple and was wrong — the curve CTE reads 90 days but only five columns, and BigQuery bills columns.

### Interface

Three new parameters, all defaulted so an existing call behaves the same shape:

- `benchmark` — `"measured"` (default) or `"study"` to force the published table. `"study"` skips the curve CTE entirely, so that path still scans only `days`.
- `curve_days` (90) — the curve window, and the cost lever.
- `min_impressions_per_rank` (100) — below this a rank falls back to the study curve instead of reporting noise.

Two new output columns: `benchmark_source` (`measured` / `study`) and `benchmark_rank_impressions`, how much data stood behind the rank each page was judged against.

That second column exists because of a mistake I made while testing. I first measured position 1 at 7.79%, not the 3.54% I quoted in #1, and had to chase it: the dataset I pointed at held 12 days of history, so a 90-day curve silently became a 12-day curve. On the full 133-day export it comes out at 3.73%. A tool that can quietly do that should say how much data it used, per row.

### Left as measured, not tidied

- **The curve is not monotonic at the top.** Rank 2 came out at 4.08% against rank 1's 3.73%, because the query mix differs between ranks. Smoothing it would report the shape a click curve is supposed to have instead of the one this property has, so it is left alone and documented at the call site. Say the word if you'd rather it were monotonic by construction.
- **Granularity mismatch.** The curve is built per `(url, query)`; the verdict lands on a page's blended position across all its queries. A page with an unusual query mix sits against a rank that doesn't describe it exactly. Much closer than a foreign study, but not a per-query judgement.

### Not included

`gsc_ctr_opportunities` has the same hardcoded curve and would benefit from the same treatment. Left out deliberately — one tool per PR. Happy to send it after this.
